### PR TITLE
Allow different types for input and output

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -443,7 +443,7 @@ func NewSession[T TensorData](onnxFilePath string, inputNames,
 	return toReturn, nil
 }
 
-func (s *Session[T, T2]) Destroy() error {
+func (s *Session[T, T1]) Destroy() error {
 	if s.ortSession != nil {
 		C.ReleaseOrtSession(s.ortSession)
 		s.ortSession = nil
@@ -462,7 +462,7 @@ func (s *Session[T, T2]) Destroy() error {
 }
 
 // Runs the session, updating the contents of the output tensors on success.
-func (s *Session[T, T2]) Run() error {
+func (s *Session[T, T1]) Run() error {
 	status := C.RunOrtSession(s.ortSession, &s.inputs[0], &s.inputNames[0],
 		C.int(len(s.inputs)), &s.outputs[0], &s.outputNames[0],
 		C.int(len(s.outputs)))


### PR DESCRIPTION
Hi,

I am not sure if this makes sense, but I needed to have different types for input and output Tensors. So, I just added another type to the session. It worked so far in my tests.

Also, thanks so much for making this library, it really helped me out!