### PR TITLE
Add MacOS arm64 to tests

### DIFF
--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -35,6 +35,9 @@ func getTestSharedLibraryPath(t testing.TB) string {
 		return "test_data/onnxruntime.dll"
 	}
 	if runtime.GOARCH == "arm64" {
+		if runtime.GOOS == "darwin" {
+			return "test_data/onnxruntime_arm64.dylib"
+		}
 		return "test_data/onnxruntime_arm64.so"
 	}
 	// TODO: If someone with apple wants to help out, add a x86 and arm64


### PR DESCRIPTION
Hello,
I have added darwin/arm64 (MacBook Air M1) to the tests.
Here is the verbose output:

cedric@macbook-air-de-cedric onnxruntime_go % go test -v                                                 
=== RUN   TestTensorTypes
    onnxruntime_test.go:123: Got data type for float64-based double: 11
--- PASS: TestTensorTypes (0.00s)
=== RUN   TestCreateTensor
    onnxruntime_test.go:158: Got expected error when creating a tensor without enough data: The tensor's shape ([2 5]) requires 10 elements, but only 1 were provided
        
--- PASS: TestCreateTensor (0.01s)
=== RUN   TestBadTensorShapes
    onnxruntime_test.go:189: Got expected error when creating a tensor with an empty shape: Invalid tensor shape: The shape has no dimensions
    onnxruntime_test.go:198: Got expected error when creating a tensor with a 0 dimension: Invalid tensor shape: Dimension 1 of the shape has invalid value 0
    onnxruntime_test.go:207: Got expected error when creating a tensor with a negative dimension: Invalid tensor shape: Dimension 2 of the shape has invalid value -10
    onnxruntime_test.go:216: Got expected error when creating a tensor with two negative dimensions: Invalid tensor shape: Dimension 1 of the shape has invalid value -10
    onnxruntime_test.go:225: Got expected error when creating a tensor with an overflowing shape: Invalid tensor shape: The shape's flattened size overflows an int64
--- PASS: TestBadTensorShapes (0.00s)
=== RUN   TestCloneTensor
--- PASS: TestCloneTensor (0.00s)
=== RUN   TestExampleNetwork
--- PASS: TestExampleNetwork (0.00s)
=== RUN   TestExampleNetworkDynamic
--- PASS: TestExampleNetworkDynamic (0.00s)
=== RUN   TestEnableDisableTelemetry
--- PASS: TestEnableDisableTelemetry (0.00s)
=== RUN   TestArbitraryTensors
    onnxruntime_test.go:384: ArbitraryTensor 0: Data type 2, shape [2 2], OrtValue 0x6000037b4100
    onnxruntime_test.go:384: ArbitraryTensor 1: Data type 11, shape [2 2], OrtValue 0x6000037b40c0
    onnxruntime_test.go:384: ArbitraryTensor 2: Data type 5, shape [2 2], OrtValue 0x6000037b4160
--- PASS: TestArbitraryTensors (0.00s)
=== RUN   TestDifferentInputOutputTypes
--- PASS: TestDifferentInputOutputTypes (0.00s)
=== RUN   TestDynamicDifferentInputOutputTypes
--- PASS: TestDynamicDifferentInputOutputTypes (0.00s)
=== RUN   TestWrongInputs
2023-08-25 08:44:16.612 onnxruntime_go.test[76434:15790508] 2023-08-25 08:44:16.611960 [E:onnxruntime:, sequential_executor.cc:514 ExecuteKernel] Non-zero status code returned while running Cast node. Name:'/Cast_1' Status Message: /Users/runner/work/1/s/include/onnxruntime/core/framework/tensor.h:189 T *onnxruntime::Tensor::MutableData() [T = short] utils::IsPrimitiveDataType<T>(dtype_) was false. Tensor type mismatch. T !=N11onnxruntime17PrimitiveDataTypeIfEE
    onnxruntime_test.go:558: Got expected error when passing a float32 tensor in place of an int16 output tensor: Error running network: Non-zero status code returned while running Cast node. Name:'/Cast_1' Status Message: /Users/runner/work/1/s/include/onnxruntime/core/framework/tensor.h:189 T *onnxruntime::Tensor::MutableData() [T = short] utils::IsPrimitiveDataType<T>(dtype_) was false. Tensor type mismatch. T !=N11onnxruntime17PrimitiveDataTypeIfEE
        
    onnxruntime_test.go:567: Got expected error when passing a float32 tensor in place of a float64 input tensor: Error running network: Unexpected input data type. Actual: (tensor(float)) , expected: (tensor(double))
    onnxruntime_test.go:582: Got expected error when running with an incorrectly shaped input: Error running network: Invalid rank for input: InputA Got: 1 Expected: 3 Please fix either the inputs or the model.
2023-08-25 08:44:16.612 onnxruntime_go.test[76434:15790508] 2023-08-25 08:44:16.612090 [E:onnxruntime:, sequential_executor.cc:514 ExecuteKernel] Non-zero status code returned while running Mul node. Name:'/Mul_1' Status Message: /Users/runner/work/1/s/onnxruntime/core/framework/execution_frame.cc:173 onnxruntime::common::Status onnxruntime::IExecutionFrame::GetOrCreateNodeOutputMLValue(const int, int, const onnxruntime::TensorShape *, OrtValue *&, const onnxruntime::Node &) shape && tensor.Shape() == *shape was false. OrtValue shape verification failed. Current shape:{1,1,1,1,1,1} Requested shape:{1,1,1}
    onnxruntime_test.go:593: Got expected error when running with an incorrectly shaped output: Error running network: Non-zero status code returned while running Mul node. Name:'/Mul_1' Status Message: /Users/runner/work/1/s/onnxruntime/core/framework/execution_frame.cc:173 onnxruntime::common::Status onnxruntime::IExecutionFrame::GetOrCreateNodeOutputMLValue(const int, int, const onnxruntime::TensorShape *, OrtValue *&, const onnxruntime::Node &) shape && tensor.Shape() == *shape was false. OrtValue shape verification failed. Current shape:{1,1,1,1,1,1} Requested shape:{1,1,1}
        
--- PASS: TestWrongInputs (0.00s)
=== RUN   TestSessionOptions
--- PASS: TestSessionOptions (0.91s)
=== RUN   TestCUDASession
    onnxruntime_test.go:734: Error creating CUDA provider options: CUDA execution provider is not enabled in this build.. Your version of the onnxruntime library may not support CUDA. Skipping the remainder of this test.
--- SKIP: TestCUDASession (0.00s)
PASS
ok  	github.com/yalue/onnxruntime_go	1.082s
