### PR TITLE
Add TensorRT Support

### DIFF
--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -78,6 +78,25 @@ OrtStatus *UpdateCUDAProviderOptions(OrtCUDAProviderOptionsV2 *o,
   return ort_api->UpdateCUDAProviderOptions(o, keys, values, num_keys);
 }
 
+OrtStatus *CreateTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 **o) {
+  return ort_api->CreateTensorRTProviderOptions(o);
+}
+
+void ReleaseTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 *o) {
+  ort_api->ReleaseTensorRTProviderOptions(o);
+}
+
+OrtStatus *UpdateTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 *o,
+  const char **keys, const char **values, int num_keys) {
+  return ort_api->UpdateTensorRTProviderOptions(o, keys, values, num_keys);
+}
+
+OrtStatus *AppendExecutionProviderTensorRTV2(OrtSessionOptions *o,
+  OrtTensorRTProviderOptionsV2 *tensor_rt_options) {
+  return ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2(o,
+    tensor_rt_options);
+}
+
 OrtStatus *CreateSession(void *model_data, size_t model_data_length,
     OrtEnv *env, OrtSession **out, OrtSessionOptions *options) {
   OrtStatus *status = NULL;

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -76,6 +76,20 @@ void ReleaseCUDAProviderOptions(OrtCUDAProviderOptionsV2 *o);
 OrtStatus *UpdateCUDAProviderOptions(OrtCUDAProviderOptionsV2 *o,
   const char **keys, const char **values, int num_keys);
 
+// Wraps ort_api->CreateTensorRTProviderOptions
+OrtStatus *CreateTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 **o);
+
+// Wraps ort_api->ReleaseTensorRTProviderOptions
+void ReleaseTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 *o);
+
+// Wraps ort_api->UpdateTensorRTProviderOptions
+OrtStatus *UpdateTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 *o,
+  const char **keys, const char **values, int num_keys);
+
+// Wraps ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2
+OrtStatus *AppendExecutionProviderTensorRTV2(OrtSessionOptions *o,
+  OrtTensorRTProviderOptionsV2 *tensor_rt_options);
+
 // Creates an ORT session using the given model. The given options pointer may
 // be NULL; if it is, then we'll use default options.
 OrtStatus *CreateSession(void *model_data, size_t model_data_length,


### PR DESCRIPTION
 - This change introduces support for enabling the TensorRT execution backend. It is configured in basically the same manner as the CUDA backend, with analogous APIs.

 - Added a unit test and benchmark for the TensorRT backend. To try it, run "go test -v -bench=." on a system where TensorRT is installed, and you're using a build of onnxruntime with TensorRT enabled.