### PR TITLE
Add CoreML support

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -598,6 +598,26 @@ func (o *SessionOptions) AppendExecutionProviderTensorRT(
 	return nil
 }
 
+// Enables the CoreML backend for the given session options on supported
+// platforms. Unlike the other AppendExecutionProvider* functions, this one
+// only takes a bitfield of flags rather than an options object, though it
+// wouldn't suprise me if onnxruntime deprecated this API in the future as it
+// did with the others. If that happens, we'll likely add a
+// CoreMLProviderOptions struct and an AppendExecutionProviderCoreMLV2 function
+// to the Go wrapper library, but for now the simpler API is the only thing
+// available.
+//
+// Regardless, the meanings of the flag bits are currently defined in the
+// coreml_provider_factor.h file which is provided in the include/ directory of
+// the onnxruntime releases for Apple platforms.
+func (o *SessionOptions) AppendExecutionProviderCoreML(flags uint32) error {
+	status := C.AppendExecutionProviderCoreML(o.o, C.uint32_t(flags))
+	if status != nil {
+		return statusToError(status)
+	}
+	return nil
+}
+
 // Initializes and returns a SessionOptions struct, used when setting options
 // in new AdvancedSession instances. The caller must call the Destroy()
 // function on the returned struct when it's no longer needed.

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -864,6 +864,7 @@ func TestCoreMLSession(t *testing.T) {
 }
 
 func BenchmarkCoreMLSession(b *testing.B) {
+	b.StopTimer()
 	InitializeRuntime(b)
 	defer CleanupRuntime(b)
 	sessionOptions := getCoreMLSessionOptions(b)

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -102,8 +102,8 @@ OrtStatus *UpdateTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 *o,
 OrtStatus *AppendExecutionProviderTensorRTV2(OrtSessionOptions *o,
   OrtTensorRTProviderOptionsV2 *tensor_rt_options);
 
-// Wraps ort_api->SessionOptionsAppendExecutionProvider_CoreML, but only on
-// Apple devices. Stubs to a function that returns an error on other platforms.
+// Wraps OrtSessionOptionsAppendExecutionProvider_CoreML, exported from the
+// dylib on Apple devices. Safely returns a non-NULL status on other platforms.
 OrtStatus *AppendExecutionProviderCoreML(OrtSessionOptions *o,
   uint32_t flags);
 

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -22,9 +22,21 @@
 extern "C" {
 #endif
 
+// Used for the OrtSessionOptionsAppendExecutionProvider_CoreML function
+// pointer on supported systems. Must match the signature in
+// coreml_provider_factory.h provided along with the onnxruntime releases for
+// Apple platforms.
+typedef OrtStatus* (*AppendCoreMLProviderFn)(OrtSessionOptions*, uint32_t);
+
 // Takes a pointer to the api_base struct in order to obtain the OrtApi
 // pointer. Intended to be called from Go. Returns nonzero on error.
 int SetAPIFromBase(OrtApiBase *api_base);
+
+// OrtSessionOptionsAppendExecutionProvider_CoreML is exported directly from
+// the Apple .dylib, so we call this function on Apple platforms to set the
+// function pointer to the correct address. On other platforms, the function
+// pointer should remain NULL.
+void SetCoreMLProviderFunctionPointer(void *ptr);
 
 // Wraps ort_api->ReleaseStatus(status)
 void ReleaseOrtStatus(OrtStatus *status);
@@ -89,6 +101,11 @@ OrtStatus *UpdateTensorRTProviderOptions(OrtTensorRTProviderOptionsV2 *o,
 // Wraps ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2
 OrtStatus *AppendExecutionProviderTensorRTV2(OrtSessionOptions *o,
   OrtTensorRTProviderOptionsV2 *tensor_rt_options);
+
+// Wraps ort_api->SessionOptionsAppendExecutionProvider_CoreML, but only on
+// Apple devices. Stubs to a function that returns an error on other platforms.
+OrtStatus *AppendExecutionProviderCoreML(OrtSessionOptions *o,
+  uint32_t flags);
 
 // Creates an ORT session using the given model. The given options pointer may
 // be NULL; if it is, then we'll use default options.

--- a/setup_env.go
+++ b/setup_env.go
@@ -4,6 +4,7 @@ package onnxruntime_go
 
 import (
 	"fmt"
+	"runtime"
 	"unsafe"
 )
 
@@ -25,8 +26,8 @@ OrtApiBase *CallGetAPIBaseFunction(void *fn) {
 import "C"
 
 // This file includes the code for loading the onnxruntime and setting up the
-// environment on non-Windows systems. For now, it has only been tested on
-// Linux.
+// environment on non-Windows systems. For now, it has been tested on Linux and
+// arm64 OSX.
 
 // This will contain the handle to the onnxruntime shared library if it has
 // been loaded successfully.
@@ -37,6 +38,22 @@ func platformCleanup() error {
 	if v != 0 {
 		return fmt.Errorf("Error closing the library: %w", e)
 	}
+	return nil
+}
+
+// Should only be called on Apple systems; looks up the CoreML provider
+// function which should only be exported on apple onnxruntime dylib files.
+// For now, this will never return an error; instead it will silently set the
+// coreml provider function to a null pointer which will be detected at
+// runtime.
+func setAppendCoreMLFunctionPointer(libraryHandle unsafe.Pointer) error {
+	// This function name must match the name in coreml_provider_factory.h,
+	// which is provided in the onnxruntime release's include/ directory on for
+	// Apple platforms.
+	cFunctionName := C.CString("OrtSessionOptionsAppendExecutionProvider_CoreML")
+	defer C.free(unsafe.Pointer(cFunctionName))
+	appendCoreMLProviderProc := C.dlsym(libraryHandle, cFunctionName)
+	C.SetCoreMLProviderFunctionPointer(appendCoreMLProviderProc)
 	return nil
 }
 
@@ -66,6 +83,17 @@ func platformInitializeEnvironment() error {
 	if tmp != 0 {
 		C.dlclose(handle)
 		return fmt.Errorf("Error setting ORT API base: %d", tmp)
+	}
+	if (runtime.GOOS == "darwin") || (runtime.GOOS == "ios") {
+		e = setAppendCoreMLFunctionPointer(handle)
+		if e != nil {
+			// This shouldn't actually ever happen in the current
+			// implementation; instead the coreml function should remain NULL,
+			// which will cause AppendExecutionProviderCoreML to return an
+			// error at runtime.
+			C.dlclose(handle)
+			return fmt.Errorf("Error finding CoreML functionality: %w", e)
+		}
 	}
 	libraryHandle = handle
 	return nil


### PR DESCRIPTION
This change should enable CoreML support on Apple platforms.  To use it, call the `AppendExecutionProviderCoreML` on a `*SessionOptions` instance, then use the options with `NewAdvancedSession` to create a `Session`.