### PR TITLE
Added option to allocate an output tensor

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -1068,7 +1068,7 @@ func createTensorFromOrtValue(v *C.OrtValue) (ArbitraryTensor, error) {
 // Runs the network on the given input and output tensors. The number of input
 // and output tensors must match the number (and order) of the input and output
 // names specified to NewDynamicAdvancedSession.
-// If a given output is null, it will be allocated and the slice will be modified
+// If a given output is nil, it will be allocated and the slice will be modified
 // to include the new tensor. The new tensor must be freed by calling Destroy on it.
 func (s *DynamicAdvancedSession) Run(inputs, outputs []ArbitraryTensor) error {
 	if len(inputs) != len(s.s.inputNames) {

--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -1003,9 +1003,73 @@ func (s *DynamicAdvancedSession) Destroy() error {
 	return s.s.Destroy()
 }
 
+func createTensorWithCData[T TensorData](shape Shape, data unsafe.Pointer) (*Tensor[T], error) {
+	totalSize := shape.FlattenedSize()
+	actualData := unsafe.Slice((*T)(data), totalSize)
+	return NewTensor[T](shape, actualData)
+}
+
+func createTensorFromOrtValue(v *C.OrtValue) (ArbitraryTensor, error) {
+	var pInfo *C.OrtTensorTypeAndShapeInfo
+	status := C.GetTensorTypeAndShape(v, &pInfo)
+	if status != nil {
+		return nil, fmt.Errorf("error getting type and shape: %w", statusToError(status))
+	}
+	var dimCount C.size_t
+	status = C.GetDimensionsCount(pInfo, &dimCount)
+	if status != nil {
+		return nil, fmt.Errorf("error getting dimensions count: %w", statusToError(status))
+	}
+	shape := make(Shape, dimCount)
+	status = C.GetDimensions(pInfo, (*C.int64_t)(&shape[0]), dimCount)
+	if status != nil {
+		return nil, fmt.Errorf("error getting dimensions: %w", statusToError(status))
+	}
+	var tensorElementType C.ONNXTensorElementDataType
+	status = C.GetTensorElementType(pInfo, (*uint32)(&tensorElementType))
+	if status != nil {
+		return nil, fmt.Errorf("error getting element type: %w", statusToError(status))
+	}
+	C.ReleaseTensorTypeAndShapeInfo(pInfo)
+	var tensorData unsafe.Pointer
+	status = C.GetTensorMutableData(v, &tensorData)
+	if status != nil {
+		return nil, fmt.Errorf("error getting tensor mutable data: %w", statusToError(status))
+	}
+
+	switch tensorType := TensorElementDataType(tensorElementType); tensorType {
+	case TensorElementDataTypeFloat:
+		return createTensorWithCData[float32](shape, tensorData)
+	case TensorElementDataTypeUint8:
+		return createTensorWithCData[uint8](shape, tensorData)
+	case TensorElementDataTypeInt8:
+		return createTensorWithCData[int8](shape, tensorData)
+	case TensorElementDataTypeUint16:
+		return createTensorWithCData[uint16](shape, tensorData)
+	case TensorElementDataTypeInt16:
+		return createTensorWithCData[int16](shape, tensorData)
+	case TensorElementDataTypeInt32:
+		return createTensorWithCData[int32](shape, tensorData)
+	case TensorElementDataTypeInt64:
+		return createTensorWithCData[int64](shape, tensorData)
+	case TensorElementDataTypeDouble:
+		return createTensorWithCData[float64](shape, tensorData)
+	case TensorElementDataTypeUint32:
+		return createTensorWithCData[uint32](shape, tensorData)
+	case TensorElementDataTypeUint64:
+		return createTensorWithCData[uint64](shape, tensorData)
+	default:
+		totalSize := shape.FlattenedSize()
+		actualData := unsafe.Slice((*byte)(tensorData), totalSize)
+		return NewCustomDataTensor(shape, actualData, tensorType)
+	}
+}
+
 // Runs the network on the given input and output tensors. The number of input
 // and output tensors must match the number (and order) of the input and output
 // names specified to NewDynamicAdvancedSession.
+// If a given output is null, it will be allocated and the slice will be modified
+// to include the new tensor. The new tensor must be freed by calling Destroy on it.
 func (s *DynamicAdvancedSession) Run(inputs, outputs []ArbitraryTensor) error {
 	if len(inputs) != len(s.s.inputNames) {
 		return fmt.Errorf("The session specified %d input names, but Run() "+
@@ -1023,13 +1087,24 @@ func (s *DynamicAdvancedSession) Run(inputs, outputs []ArbitraryTensor) error {
 	}
 	outputValues := make([]*C.OrtValue, len(outputs))
 	for i, v := range outputs {
-		outputValues[i] = v.GetInternals().ortValue
+		if v != nil {
+			outputValues[i] = v.GetInternals().ortValue
+		}
 	}
 	status := C.RunOrtSession(s.s.ortSession, &inputValues[0],
 		&s.s.inputNames[0], C.int(len(inputs)), &outputValues[0],
 		&s.s.outputNames[0], C.int(len(outputs)))
 	if status != nil {
 		return fmt.Errorf("Error running network: %w", statusToError(status))
+	}
+	for i, v := range outputs {
+		if v == nil {
+			var err error
+			outputs[i], err = createTensorFromOrtValue(outputValues[i])
+			if err != nil {
+				return fmt.Errorf("Error creating tensor from ort: %w", err)
+			}
+		}
 	}
 	return nil
 }

--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -157,3 +157,27 @@ OrtStatus *CreateOrtTensorWithShape(void *data, size_t data_size,
     shape, shape_size, dtype, out);
   return status;
 }
+
+OrtStatus *GetTensorTypeAndShape(const OrtValue *value, OrtTensorTypeAndShapeInfo **out) {
+  return ort_api->GetTensorTypeAndShape(value, out);
+}
+
+OrtStatus *GetDimensionsCount(const OrtTensorTypeAndShapeInfo *info, size_t *out) {
+  return ort_api->GetDimensionsCount(info, out);
+}
+
+OrtStatus *GetDimensions(const OrtTensorTypeAndShapeInfo *info, int64_t *dim_values, size_t dim_values_length) {
+  return ort_api->GetDimensions(info, dim_values, dim_values_length);
+}
+
+OrtStatus *GetTensorElementType(const OrtTensorTypeAndShapeInfo *info, enum ONNXTensorElementDataType *out) {
+  return ort_api->GetTensorElementType(info, out);
+}
+
+void ReleaseTensorTypeAndShapeInfo(OrtTensorTypeAndShapeInfo *input) {
+  ort_api->ReleaseTensorTypeAndShapeInfo(input);
+}
+
+OrtStatus *GetTensorMutableData(OrtValue *value, void **out) {
+  return ort_api->GetTensorMutableData(value, out);
+}

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -130,6 +130,24 @@ OrtStatus *CreateOrtTensorWithShape(void *data, size_t data_size,
   int64_t *shape, int64_t shape_size, OrtMemoryInfo *mem_info,
   ONNXTensorElementDataType dtype, OrtValue **out);
 
+// Wraps ort_api->GetTensorTypeAndShape
+OrtStatus *GetTensorTypeAndShape(const OrtValue *value, OrtTensorTypeAndShapeInfo **out);
+
+// Wraps ort_api->GetDimensionsCount
+OrtStatus *GetDimensionsCount(const OrtTensorTypeAndShapeInfo *info, size_t *out);
+
+// Wraps ort_api->GetDimensions
+OrtStatus *GetDimensions(const OrtTensorTypeAndShapeInfo *info, int64_t *dim_values, size_t dim_values_length);
+
+// Wraps ort_api->GetTensorElementType
+OrtStatus *GetTensorElementType(const OrtTensorTypeAndShapeInfo *info, enum ONNXTensorElementDataType *out);
+
+// Wraps ort_api->ReleaseTensorTypeAndShapeInfo
+void ReleaseTensorTypeAndShapeInfo(OrtTensorTypeAndShapeInfo *input);
+
+// Wraps ort_api->GetTensorMutableData
+OrtStatus *GetTensorMutableData(OrtValue *value, void **out);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
I added an option to pass a null tensor to `DynamicAdvancedSession.Run()`, which will allocate the tensor and populate the slice with the new tensor. This is similar to the behaviour of the C/C++ API, and can be useful when the output shape can't be predicted at ahead of time (such as image object detection).
Example usage:
```go
session, _ := ort.NewDynamicAdvancedSession(/* parameters */)
outputs := []ort.ArbitraryTensor{nil, nil}
_ = session.Run(inputs, outputs)
confidence := outputs[0].(*ort.Tensor[float32])
defer confidence.Destroy()
bbox := outputs[1].(*ort.Tensor[float32])
defer bbox.Destroy()
```