### PR TITLE
Add sessionOptions to set CpuMemArena and MemPattern

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -757,6 +757,34 @@ func (o *SessionOptions) SetInterOpNumThreads(n int) error {
 	return nil
 }
 
+// Enable/Disable the usage of the memory arena on CPU.
+// Arena may pre-allocate memory for future usage.
+func (o *SessionOptions) SetCpuMemArena(isEnabled bool) error {
+	n := 0
+	if isEnabled {
+		n = 1
+	}
+	status := C.SetCpuMemArena(o.o, C.int(n))
+	if status != nil {
+		return statusToError(status)
+	}
+	return nil
+}
+
+// Enable/Disable the memory pattern optimization.
+// If this is enabled memory is preallocated if all shapes are known.
+func (o *SessionOptions) SetMemPattern(isEnabled bool) error {
+	n := 0
+	if isEnabled {
+		n = 1
+	}
+	status := C.SetMemPattern(o.o, C.int(n))
+	if status != nil {
+		return statusToError(status)
+	}
+	return nil
+}
+
 // Takes a pointer to an initialized CUDAProviderOptions instance, and applies
 // them to the session options. This is what you'll need to call if you want
 // the session to use CUDA. Returns an error if your device (or onnxruntime

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -926,6 +926,16 @@ func TestSessionOptions(t *testing.T) {
 		t.Logf("Error setting inter-op num threads: %s\n", e)
 		t.FailNow()
 	}
+	e = options.SetCpuMemArena(true)
+	if e != nil {
+		t.Logf("Error setting CPU memory arena: %s\n", e)
+		t.FailNow()
+	}
+	e = options.SetMemPattern(true)
+	if e != nil {
+		t.Logf("Error setting memory pattern: %s\n", e)
+		t.FailNow()
+	}
 	testBigSessionWithOptions(t, options)
 }
 

--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -65,6 +65,18 @@ OrtStatus *SetInterOpNumThreads(OrtSessionOptions *o, int n) {
   return ort_api->SetInterOpNumThreads(o, n);
 }
 
+OrtStatus *SetCpuMemArena(OrtSessionOptions *o, int use_arena){
+  if (use_arena)
+    return ort_api->EnableCpuMemArena(o);
+  return ort_api->DisableCpuMemArena(o);
+}
+
+OrtStatus *SetMemPattern(OrtSessionOptions *o, int use_mem_pattern){
+  if (use_mem_pattern)
+    return ort_api->EnableMemPattern(o);
+  return ort_api->DisableMemPattern(o);
+}
+
 OrtStatus *AppendExecutionProviderCUDAV2(OrtSessionOptions *o,
   OrtCUDAProviderOptionsV2 *cuda_options) {
   return ort_api->SessionOptionsAppendExecutionProvider_CUDA_V2(o,

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -74,6 +74,12 @@ OrtStatus *SetIntraOpNumThreads(OrtSessionOptions *o, int n);
 // Wraps ort_api->SetInterOpNumThreads
 OrtStatus *SetInterOpNumThreads(OrtSessionOptions *o, int n);
 
+// Wraps ort_api->EnableCpuMemArena & ort_api->DisableCpuMemArena
+OrtStatus *SetCpuMemArena(OrtSessionOptions *o, int use_arena);
+
+// Wraps ort_api->EnableMemPattern & ort_api->DisableMemPattern
+OrtStatus *SetMemPattern(OrtSessionOptions *o, int use_mem_pattern);
+
 // Wraps ort_api->SessionOptionsAppendExecutionProvider_CUDA_V2
 OrtStatus *AppendExecutionProviderCUDAV2(OrtSessionOptions *o,
   OrtCUDAProviderOptionsV2 *cuda_options);


### PR DESCRIPTION
Thanks for creating this wrapper for Microsoft onnx runtime.

**Issue**
Memory leaks when creating and destroying sessions in a goroutine.

**Solution**
Disabling CpuMemArena, will disable the CPU to preallocate memory. 
https://github.com/microsoft/onnxruntime/issues/11118 

