### PR TITLE
Add DirectML support

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -833,6 +833,18 @@ func (o *SessionOptions) AppendExecutionProviderCoreML(flags uint32) error {
 	return nil
 }
 
+// Enables the DirectML backend for the given session options on supported
+// platforms. See the notes on device_id in coreml_provider_factory.h in the
+// onnxruntime source code, but a device ID should correspond to the default
+// device, "which is typically the primary display GPU" according to the docs.
+func (o *SessionOptions) AppendExecutionProviderDirectML(deviceID int) error {
+	status := C.AppendExecutionProviderDirectML(o.o, C.int(deviceID))
+	if status != nil {
+		return statusToError(status)
+	}
+	return nil
+}
+
 // Initializes and returns a SessionOptions struct, used when setting options
 // in new AdvancedSession instances. The caller must call the Destroy()
 // function on the returned struct when it's no longer needed.

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -1117,3 +1117,35 @@ func BenchmarkCoreMLSession(b *testing.B) {
 	defer sessionOptions.Destroy()
 	benchmarkBigSessionWithOptions(b, sessionOptions)
 }
+
+func getDirectMLSessionOptions(t testing.TB) *SessionOptions {
+	options, e := NewSessionOptions()
+	if e != nil {
+		t.Logf("Error creating session options: %s\n", e)
+		t.FailNow()
+	}
+	e = options.AppendExecutionProviderDirectML(0)
+	if e != nil {
+		options.Destroy()
+		t.Skipf("Couldn't enable DirectML: %s. This may be due to your "+
+			"system or onnxruntime library version not supporting DirectML.\n",
+			e)
+	}
+	return options
+}
+
+func TestDirectMLSession(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+	sessionOptions := getDirectMLSessionOptions(t)
+	defer sessionOptions.Destroy()
+	testBigSessionWithOptions(t, sessionOptions)
+}
+
+func BenchmarkDirectMLSession(b *testing.B) {
+	InitializeRuntime(b)
+	defer CleanupRuntime(b)
+	sessionOptions := getDirectMLSessionOptions(b)
+	defer sessionOptions.Destroy()
+	benchmarkBigSessionWithOptions(b, sessionOptions)
+}

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -113,6 +113,11 @@ OrtStatus *AppendExecutionProviderTensorRTV2(OrtSessionOptions *o,
 OrtStatus *AppendExecutionProviderCoreML(OrtSessionOptions *o,
   uint32_t flags);
 
+// Wraps getting the OrtDmlApi struct and calling
+// dml_api->SessionOptionsAppendExecutionProvider_DML.
+OrtStatus *AppendExecutionProviderDirectML(OrtSessionOptions *o,
+  int device_id);
+
 // Creates an ORT session using the given model. The given options pointer may
 // be NULL; if it is, then we'll use default options.
 OrtStatus *CreateSession(void *model_data, size_t model_data_length,


### PR DESCRIPTION
 - This commit adds bindings to enable DirectML on supported onnxruntime builds and systems.

 - I couldn't get the tests to run on my own system, so this needs to be tested.

 - I am still not happy with copying the OrtDmlApi struct, but think it's better than the "proper" alternative of trying to pull in the dml_provider_factory.h header.