### PR TITLE
Support OpenVINO Execution Provider

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -846,6 +846,33 @@ func (o *SessionOptions) AppendExecutionProviderDirectML(deviceID int) error {
 	return nil
 }
 
+// Enables the OpenVINO backend for the given session options on supported
+// platforms. See
+// https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#summary-of-options
+// for a list of supported keys and values that can be passed in the options
+// map.
+func (o *SessionOptions) AppendExecutionProviderOpenVINO(
+	options map[string]string) error {
+	// There's probably a more concise way to do this, but we don't want to
+	// do "&(keys[0])" if keys is an empty slice, so we'll declare the null
+	// ptrs ahead of time and only set them if we know the slices aren't empty.
+	var keysPtr, valuesPtr **C.char
+	if len(options) != 0 {
+		keys, values := mapToCStrings(options)
+		defer freeCStrings(keys)
+		defer freeCStrings(values)
+		keysPtr = &(keys[0])
+		valuesPtr = &(values[0])
+	}
+
+	status := C.AppendExecutionProviderOpenVINOV2(o.o, keysPtr, valuesPtr,
+		C.int(len(options)))
+	if status != nil {
+		return statusToError(status)
+	}
+	return nil
+}
+
 // Initializes and returns a SessionOptions struct, used when setting options
 // in new AdvancedSession instances. The caller must call the Destroy()
 // function on the returned struct when it's no longer needed.

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -1425,9 +1425,43 @@ func TestDirectMLSession(t *testing.T) {
 }
 
 func BenchmarkDirectMLSession(b *testing.B) {
+	b.StopTimer()
 	InitializeRuntime(b)
 	defer CleanupRuntime(b)
 	sessionOptions := getDirectMLSessionOptions(b)
+	defer sessionOptions.Destroy()
+	benchmarkBigSessionWithOptions(b, sessionOptions)
+}
+
+func getOpenVINOSessionOptions(t testing.TB) *SessionOptions {
+	options, e := NewSessionOptions()
+	if e != nil {
+		t.Logf("Error creating session options: %s\n", e)
+		t.FailNow()
+	}
+	e = options.AppendExecutionProviderOpenVINO(map[string]string{})
+	if e != nil {
+		options.Destroy()
+		t.Skipf("Couldn't enable OpenVINO: %s. This may be due to your "+
+			"system or onnxruntime library version not supporting OpenVINO.\n",
+			e)
+	}
+	return options
+}
+
+func TestOpenVINOSession(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+	sessionOptions := getOpenVINOSessionOptions(t)
+	defer sessionOptions.Destroy()
+	testBigSessionWithOptions(t, sessionOptions)
+}
+
+func BenchmarkOpenVINOSession(b *testing.B) {
+	b.StopTimer()
+	InitializeRuntime(b)
+	defer CleanupRuntime(b)
+	sessionOptions := getOpenVINOSessionOptions(b)
 	defer sessionOptions.Destroy()
 	benchmarkBigSessionWithOptions(b, sessionOptions)
 }

--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -161,6 +161,12 @@ OrtStatus *AppendExecutionProviderDirectML(OrtSessionOptions *o,
   return status;
 }
 
+OrtStatus *AppendExecutionProviderOpenVINOV2(OrtSessionOptions *o,
+  const char **keys, const char **values, int num_keys) {
+  return ort_api->SessionOptionsAppendExecutionProvider_OpenVINO_V2(o, keys,
+    values, num_keys);
+}
+
 OrtStatus *CreateSession(void *model_data, size_t model_data_length,
     OrtEnv *env, OrtSession **out, OrtSessionOptions *options) {
   OrtStatus *status = NULL;

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -118,6 +118,10 @@ OrtStatus *AppendExecutionProviderCoreML(OrtSessionOptions *o,
 OrtStatus *AppendExecutionProviderDirectML(OrtSessionOptions *o,
   int device_id);
 
+// Wraps ort_api->AppendExecutionProvider_OpenVINO_V2
+OrtStatus *AppendExecutionProviderOpenVINOV2(OrtSessionOptions *o,
+  const char **keys, const char **values, int num_keys);
+
 // Creates an ORT session using the given model. The given options pointer may
 // be NULL; if it is, then we'll use default options.
 OrtStatus *CreateSession(void *model_data, size_t model_data_length,


### PR DESCRIPTION
 - Add SessionOptions.AppendExecutionProviderOpenVINO, which should enable the OpenVINO execution provider on supported systems. Internally it calls the SessionOptionsAppendExecutionProvider_OpenVINO_V2 API.

 - Addresses Issue #34.