### PR TITLE
📃 Add API for get version of the onnxruntime library

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -45,6 +45,11 @@ func (e *BadShapeDimensionError) Error() string {
 		e.DimensionIndex, e.DimensionSize)
 }
 
+// GetVersion return version of the Onnxruntime library for logging.
+func GetVersion() string {
+	return C.GoString(C.GetVersion())
+}
+
 // Does two things: converts the given OrtStatus to a Go error, and releases
 // the status. If the status is nil, this does nothing and returns nil.
 func statusToError(status *C.OrtStatus) error {

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -41,6 +41,9 @@ func getTestSharedLibraryPath(t testing.TB) string {
 		}
 		return "test_data/onnxruntime_arm64.so"
 	}
+	if runtime.GOARCH == "amd64" && runtime.GOOS == "darwin" {
+		return "test_data/onnxruntime_amd64.dylib"
+	}
 	return "test_data/onnxruntime.so"
 }
 
@@ -114,6 +117,15 @@ func newTestTensor[T TensorData](t testing.TB, s Shape) *Tensor[T] {
 		t.FailNow()
 	}
 	return toReturn
+}
+
+func TestGetVersion(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+	if version := GetVersion(); version == "" {
+		t.Log("Not found version onnxruntime library")
+		t.FailNow()
+	}
 }
 
 func TestTensorTypes(t *testing.T) {

--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -1,6 +1,7 @@
 #include "onnxruntime_wrapper.h"
 
 static const OrtApi *ort_api = NULL;
+static const char *ORT_VERSION = NULL;
 
 static AppendCoreMLProviderFn append_coreml_provider_fn = NULL;
 
@@ -33,8 +34,13 @@ typedef struct {
 int SetAPIFromBase(OrtApiBase *api_base) {
   if (!api_base) return 1;
   ort_api = api_base->GetApi(ORT_API_VERSION);
+  ORT_VERSION = api_base->GetVersionString();
   if (!ort_api) return 2;
   return 0;
+}
+
+const char *GetVersion() {
+  return ORT_VERSION;
 }
 
 void SetCoreMLProviderFunctionPointer(void *ptr) {

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -32,6 +32,9 @@ typedef OrtStatus* (*AppendCoreMLProviderFn)(OrtSessionOptions*, uint32_t);
 // pointer. Intended to be called from Go. Returns nonzero on error.
 int SetAPIFromBase(OrtApiBase *api_base);
 
+// Get the version of the Onnxruntime library for logging.
+const char *GetVersion();
+
 // OrtSessionOptionsAppendExecutionProvider_CoreML is exported directly from
 // the Apple .dylib, so we call this function on Apple platforms to set the
 // function pointer to the correct address. On other platforms, the function


### PR DESCRIPTION
Add API from onnxruntime library (**GetVersionString()**): https://onnxruntime.ai/docs/api/c/namespace_ort.html#aab1b2d08af45de1d59ce7d86196cd72d

This function in Go (**GetVersion**) returns the onnxruntime version string.

### How to use:
```go
package main

import (
	"fmt"
	"log"

	ort "github.com/yalue/onnxruntime_go"
)

func main() {
	if e := ort.InitializeEnvironment(); e != nil {
		log.Fatalf("Error initializing onnxruntime library: %v", e)
	}
	defer ort.DestroyEnvironment()

	version := ort.GetVersion()
	fmt.Println(version)
}
```

__Thank you very much for the work done on integration onnxruntime in Golang__


