### PR TITLE
Replace `ArbitraryTensor` with `Value`, test updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,9 @@ Tests
  - In short, after _every_ change, `go test -v -bench=.` must pass on _every_
    supported platform.
 
+ - Every test failure should be accompanied by a message containing the reason,
+   either using `t.Logf()`, `t.Errorf()`, or `t.Fatalf()`.
+
 
 Adding New Files
 ----------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,17 +40,17 @@ Documentation
 Tests
 -----
 
- - All new features must include a basic unit test (in `onnxruntime_test.go` or
-   `onnxruntime_training_test.go`) to serve as a sanity check.
+ - All new features and bugfixes must include a basic unit test (in
+   `onnxruntime_test.go` or `onnxruntime_training_test.go`) to serve as a
+   sanity check.
 
  - If a test is for an platform-dependent or execution-provider-dependent
-   feature, the test must be skipped on systems if run on an unsupported
-   system.
+   feature, the test must be skipped if run on an unsupported system.
 
  - No tests should panic.  Always check errors and fail rather than allowing
    tests to panic.
 
- - In short, after _every_ change, `go test -v -bench=.` must pass on _every_
+ - Every change must ensure that `go test -v -bench=.` passes on every
    supported platform.
 
  - Every test failure should be accompanied by a message containing the reason,
@@ -60,7 +60,7 @@ Tests
 Adding New Files
 ----------------
 
- - Try not to add new files unless absolutely necessary.
+ - Apart from testing data, try not to add new source files.
 
  - Do not add third-party code or headers.  The only exceptions for now are
    `onnxruntime_c_api.h` and `onnxruntime_training_c_api.h`.
@@ -72,13 +72,12 @@ Adding New Files
    `x86_64` Linux), but I do not want this project turning into an unofficial
    distribution channel for onnxruntime libraries.  It also clogs up the git
    repo with large files, and increases the size of the history every time
-   these files are updated.  The libraries that are included _only_ serve to
-   ensure that running `go test -v -bench=.` will run and succeed without
-   modification for a large portion of users. Currently: amd64 Windows,
-   arm64 Linux (I wish I hadn't included this!), arm64 osx, and
-   amd64 osx. All other users must set the `ONNXRUNTIME_SHARED_LIBRARY_PATH`
-   environment variable to a valid path to the correct `onnxruntime` shared
-   library file prior to running `go test -v`.
+   these files are updated.  The libraries that are included were only intended
+   to allow a majority of users to run `go test -v -bench=.` without further
+   setup or modification. Currently: amd64 Windows, arm64 Linux (I wish I
+   hadn't included this!), arm64 osx, and amd64 osx. All other users must set
+   the `ONNXRUNTIME_SHARED_LIBRARY_PATH` environment variable to a valid path
+   to the correct `onnxruntime` shared library file prior to running tests.
 
  - If you need to add a .onnx file for a test, place both the .onnx file
    _and_ the script used to generate it into `test_data/`.
@@ -97,7 +96,8 @@ Dependencies
    it would be great to keep it this way.
 
  - Python scripts within `test_data/` can use whatever dependencies they need,
-   so long as the `.onnx` file they produce is already included.
+   because the `.onnx` file they produce should already be included and end
+   users should not be required to run them.
 
 
 C-Specific Stuff

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+Contribution Guidelines
+=======================
+
+This library began as a personal project, and is primarily still maintained as
+such.  The following list of guidelines is not necessarily exhaustive, and,
+ultimately, any contribution is subject to the maintainer's discretion. That
+being said, contributions are welcome, and most recent new features have been
+added by users who need them!
+
+Coding Style
+------------
+
+ - Go code must be formatted using the official `gofmt` tool.
+
+ - C code should adhere to the portions of Google's C++ style guide, as they
+   apply to C.
+
+ - If at all possible, any Go or C code should have at most 80 character lines.
+   (This may not be enforced very strictly.)
+
+ - Purely stylistic changes are unlikely to be accepted. Instead, the
+   maintainer or other contributers may make small stylistic adjustments to
+   surrounding code as part of other contributions.
+
+ - Attempt to mimic the existing style of the surrounding code.
+
+
+Documentation
+-------------
+
+ - All Go types and public-facing functions must include a comment on their
+   intended usage, to be parsed by godoc.
+
+ - As per the google C++ style guide, all C functions must be documented with a
+   comment as well.  If a C function is defined in a header file, the comment
+   should appear with the definition in the header. If it's a static function
+   in a `.c` file, the comment should appear with the function definition.
+
+
+Tests
+-----
+
+ - All new features must include a basic unit test (in `onnxruntime_test.go` or
+   `onnxruntime_training_test.go`) to serve as a sanity check.
+
+ - If a test is for an platform-dependent or execution-provider-dependent
+   feature, the test must be skipped on systems if run on an unsupported
+   system.
+
+ - No tests should panic.  Always check errors and fail rather than allowing
+   tests to panic.
+
+ - In short, after _every_ change, `go test -v -bench=.` must pass on _every_
+   supported platform.
+
+
+Adding New Files
+----------------
+
+ - Try not to add new files unless absolutely necessary.
+
+ - Do not add third-party code or headers.  The only exceptions for now are
+   `onnxruntime_c_api.h` and `onnxruntime_training_c_api.h`.
+
+ - No C++ at all. Developing Go-to-C wrappers is annoying enough as it is.
+
+ - Do not add any new `onnxruntime` shared libraries under `test_data`. I know
+   there are additional platforms that would be nice to include (such as
+   `x86_64` Linux), but I do not want this project turning into an unofficial
+   distribution channel for onnxruntime libraries.  It also clogs up the git
+   repo with large files, and increases the size of the history every time
+   these files are updated.  The libraries that are included _only_ serve to
+   ensure that running `go test -v -bench=.` will run and succeed without
+   modification for a large portion of users. Currently: amd64 Windows,
+   arm64 Linux (I wish I hadn't included this!), arm64 osx, and
+   amd64 osx. All other users must set the `ONNXRUNTIME_SHARED_LIBRARY_PATH`
+   environment variable to a valid path to the correct `onnxruntime` shared
+   library file prior to running `go test -v`.
+
+ - If you need to add a .onnx file for a test, place both the .onnx file
+   _and_ the script used to generate it into `test_data/`.
+
+ - Keep any testing .onnx files as small as possible.
+
+ - Without a good reason (i.e., implementing an entire class of APIs such as
+   training), avoid adding new Go files---just add to `onnxruntime_go.go`.
+
+
+Dependencies
+------------
+
+ - Avoid Go or C dependencies outside of the language's standard libraries.
+   This package currently does not depend on any third-party Go modules, and
+   it would be great to keep it this way.
+
+ - Python scripts within `test_data/` can use whatever dependencies they need,
+   so long as the `.onnx` file they produce is already included.
+
+
+C-Specific Stuff
+----------------
+
+ - Minimize Go management of C-allocated memory as much as possible. For
+   example, see the `convertORTString` function on `onnxruntime_go.go`, which
+   copies a C-allocated string into a garbage-collected `go` string.
+
+ - If you need to use a `OrtAllocator` in onnxruntime's C API, always use the
+   default `OrtAllocator` returned by
+   `ort_api->GetAllocatorWithDefaultOptions()`.
+
+
+A Few Notes on Organization
+---------------------------
+
+ - The `onnxruntime` C API uses a struct containing function pointers. Cgo
+   can't directly invoke functions via pointers, so `onnxruntime_wrapper.c`
+   (along with the associated header file) are used to provide top-level C
+   functions that call the function pointers within the `OrtApi` struct.
+
+ - Linux and OSX use `dlopen` to load the onnxruntime shared library, but this
+   isn't possible on Windows, which instead can use the `syscall.LoadLibrary()`
+   function from Go's standard library. This different behavior is locked
+   behind build constraints in `setup_env.go` and `setup_env_windows.go`,
+   respectively.
+

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ func main() {
 
     session, err := ort.NewAdvancedSession("path/to/network.onnx",
         []string{"Input 1 Name"}, []string{"Output 1 Name"},
-        []ort.ArbitraryTensor{inputTensor}, []ort.ArbitraryTensor{outputTensor}, nil)
+        []ort.Value{inputTensor}, []ort.Value{outputTensor}, nil)
     defer session.Destroy()
 
     // Calling Run() will run the network, reading the current contents of the

--- a/README.md
+++ b/README.md
@@ -197,3 +197,27 @@ load a library from `test_data/`. So, if you are using one of these systems or
 want accelerator-related tests to run, you should set the environment variable
 to the path to the onnxruntime shared library.  Afterwards, `go test -v` should
 run and pass.
+
+
+Training API Support
+--------------------
+
+This wrapper supports the onnxruntime training API on limited platforms. See
+the `NewTrainingSession` and associated data types or functions to use it. So
+far, the training API has only been tested on Linux, on `x86_64` architectures.
+
+If you are not sure whether your platform or build of onnxruntime supports
+training, you can call `onnxruntime_go.IsTrainingSupported()`, which will
+return `true` if training is supported on your system.
+
+*The training API is not currently supported on Windows.*  While training
+support has simply not been tested on other Linux and Mac systems, it is
+currently known to be unsupported on Windows.  This is due to
+`NewTrainingSession` fundamentally requiring filesystem paths, even within the
+C API.  This is difficult to handle in Windows, since the Windows onnxruntime
+DLLs require wide-character strings (unlike the Linux and osx shared
+libraries).  This means that calling these functions on Windows would require
+converting UTF-8 Go `string`s to compatible strings when invoking the C API on
+Windows only. This should possible, but it is simply not a development priority
+at the moment.
+

--- a/legacy_types.go
+++ b/legacy_types.go
@@ -46,8 +46,8 @@ func NewSessionWithONNXData[T TensorData](onnxData []byte, inputNames,
 	// Unfortunately, a slice of pointers that satisfy an interface don't count
 	// as a slice of interfaces (at least, as I write this), so we'll make the
 	// conversion here.
-	tmpInputs := make([]ArbitraryTensor, len(inputs))
-	tmpOutputs := make([]ArbitraryTensor, len(outputs))
+	tmpInputs := make([]Value, len(inputs))
+	tmpOutputs := make([]Value, len(outputs))
 	for i, t := range inputs {
 		tmpInputs[i] = t
 	}

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -55,8 +55,7 @@ func InitializeRuntime(t testing.TB) {
 	SetSharedLibraryPath(getTestSharedLibraryPath(t))
 	e := InitializeEnvironment()
 	if e != nil {
-		t.Logf("Failed setting up onnxruntime environment: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed setting up onnxruntime environment: %s\n", e)
 	}
 }
 
@@ -64,8 +63,7 @@ func InitializeRuntime(t testing.TB) {
 func CleanupRuntime(t testing.TB) {
 	e := DestroyEnvironment()
 	if e != nil {
-		t.Logf("Error cleaning up environment: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error cleaning up environment: %s\n", e)
 	}
 }
 
@@ -74,15 +72,13 @@ func parseInputsJSON(path string, t testing.TB) *testInputsInfo {
 	toReturn := testInputsInfo{}
 	f, e := os.Open(path)
 	if e != nil {
-		t.Logf("Failed opening %s: %s\n", path, e)
-		t.FailNow()
+		t.Fatalf("Failed opening %s: %s\n", path, e)
 	}
 	defer f.Close()
 	d := json.NewDecoder(f)
 	e = d.Decode(&toReturn)
 	if e != nil {
-		t.Logf("Failed decoding %s: %s\n", path, e)
-		t.FailNow()
+		t.Fatalf("Failed decoding %s: %s\n", path, e)
 	}
 	return &toReturn
 }
@@ -113,8 +109,7 @@ func floatsEqual(a, b []float32) error {
 func newTestTensor[T TensorData](t testing.TB, s Shape) *Tensor[T] {
 	toReturn, e := NewEmptyTensor[T](s)
 	if e != nil {
-		t.Logf("Failed creating empty tensor with shape %s: %s\n", s, e)
-		t.FailNow()
+		t.Fatalf("Failed creating empty tensor with shape %s: %s\n", s, e)
 	}
 	return toReturn
 }
@@ -122,10 +117,11 @@ func newTestTensor[T TensorData](t testing.TB, s Shape) *Tensor[T] {
 func TestGetVersion(t *testing.T) {
 	InitializeRuntime(t)
 	defer CleanupRuntime(t)
-	if version := GetVersion(); version == "" {
-		t.Log("Not found version onnxruntime library")
-		t.FailNow()
+	version := GetVersion()
+	if version == "" {
+		t.Fatalf("Not found version onnxruntime library")
 	}
+	t.Logf("Found onnxruntime library version: %s\n", version)
 }
 
 func TestTensorTypes(t *testing.T) {
@@ -133,9 +129,8 @@ func TestTensorTypes(t *testing.T) {
 	dataType := TensorElementDataType(GetTensorElementDataType[myFloat]())
 	expected := TensorElementDataType(TensorElementDataTypeDouble)
 	if dataType != expected {
-		t.Logf("Expected float64 data type to be %d (%s), got %d (%s)\n",
+		t.Fatalf("Expected float64 data type to be %d (%s), got %d (%s)\n",
 			expected, expected, dataType, dataType)
-		t.FailNow()
 	}
 	t.Logf("Got data type for float64-based double: %d (%s)\n",
 		dataType, dataType)
@@ -147,8 +142,7 @@ func TestCreateTensor(t *testing.T) {
 	s := NewShape(1, 2, 3)
 	tensor1, e := NewEmptyTensor[uint8](s)
 	if e != nil {
-		t.Logf("Failed creating %s uint8 tensor: %s\n", s, e)
-		t.FailNow()
+		t.Fatalf("Failed creating %s uint8 tensor: %s\n", s, e)
 	}
 	defer tensor1.Destroy()
 	if len(tensor1.GetData()) != 6 {
@@ -159,9 +153,8 @@ func TestCreateTensor(t *testing.T) {
 	// passed to NewEmptyTensor.
 	s[1] = 3
 	if tensor1.GetShape()[1] == s[1] {
-		t.Logf("Modifying the original shape incorrectly changed the " +
+		t.Fatalf("Modifying the original shape incorrectly changed the " +
 			"tensor's shape.\n")
-		t.FailNow()
 	}
 
 	// Try making a tensor with a different data type.
@@ -169,9 +162,8 @@ func TestCreateTensor(t *testing.T) {
 	data := []float32{1.0}
 	_, e = NewTensor(s, data)
 	if e == nil {
-		t.Logf("Didn't get error when creating a tensor with too little " +
+		t.Fatalf("Didn't get error when creating a tensor with too little " +
 			"data.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when creating a tensor without enough data: "+
 		"%s\n", e)
@@ -181,16 +173,14 @@ func TestCreateTensor(t *testing.T) {
 	data = []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}
 	tensor2, e := NewTensor(s, data)
 	if e != nil {
-		t.Logf("Error creating tensor with data: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating tensor with data: %s\n", e)
 	}
 	defer tensor2.Destroy()
 	// Make sure the tensor's internal slice only refers to the part we care
 	// about, and not the entire slice.
 	if len(tensor2.GetData()) != 10 {
-		t.Logf("New tensor data contains %d elements, when it should "+
+		t.Fatalf("New tensor data contains %d elements, when it should "+
 			"contain 10.\n", len(tensor2.GetData()))
-		t.FailNow()
 	}
 }
 
@@ -200,45 +190,40 @@ func TestBadTensorShapes(t *testing.T) {
 	s := NewShape()
 	_, e := NewEmptyTensor[float64](s)
 	if e == nil {
-		t.Logf("Didn't get an error when creating a tensor with an empty " +
+		t.Fatalf("Didn't get an error when creating a tensor with an empty " +
 			"shape.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when creating a tensor with an empty shape: "+
 		"%s\n", e)
 	s = NewShape(10, 0, 10)
 	_, e = NewEmptyTensor[uint16](s)
 	if e == nil {
-		t.Logf("Didn't get an error when creating a tensor with a shape " +
+		t.Fatalf("Didn't get an error when creating a tensor with a shape " +
 			"containing a 0 dimension.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when creating a tensor with a 0 dimension: "+
 		"%s\n", e)
 	s = NewShape(10, 10, -10)
 	_, e = NewEmptyTensor[int32](s)
 	if e == nil {
-		t.Logf("Didn't get an error when creating a tensor with a negative " +
-			"dimension.\n")
-		t.FailNow()
+		t.Fatalf("Didn't get an error when creating a tensor with a negative" +
+			" dimension.\n")
 	}
 	t.Logf("Got expected error when creating a tensor with a negative "+
 		"dimension: %s\n", e)
 	s = NewShape(10, -10, -10)
 	_, e = NewEmptyTensor[uint64](s)
 	if e == nil {
-		t.Logf("Didn't get an error when creating a tensor with two " +
+		t.Fatalf("Didn't get an error when creating a tensor with two " +
 			"negative dimensions.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when creating a tensor with two negative "+
 		"dimensions: %s\n", e)
 	s = NewShape(int64(1)<<62, 1, int64(1)<<62)
 	_, e = NewEmptyTensor[float32](s)
 	if e == nil {
-		t.Logf("Didn't get an error when creating a tensor with an " +
+		t.Fatalf("Didn't get an error when creating a tensor with an " +
 			"overflowing shape.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when creating a tensor with an overflowing "+
 		"shape: %s\n", e)
@@ -250,31 +235,26 @@ func TestCloneTensor(t *testing.T) {
 	originalData := []float32{1, 2, 3, 4}
 	originalTensor, e := NewTensor(NewShape(2, 2), originalData)
 	if e != nil {
-		t.Logf("Error creating tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating tensor: %s\n", e)
 	}
 	clone, e := originalTensor.Clone()
 	if e != nil {
-		t.Logf("Error cloning tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error cloning tensor: %s\n", e)
 	}
 	if !clone.GetShape().Equals(originalTensor.GetShape()) {
-		t.Logf("Clone shape (%s) doesn't match original shape (%s)\n",
+		t.Fatalf("Clone shape (%s) doesn't match original shape (%s)\n",
 			clone.GetShape(), originalTensor.GetShape())
-		t.FailNow()
 	}
 	cloneData := clone.GetData()
 	for i := range originalData {
 		if cloneData[i] != originalData[i] {
-			t.Logf("Clone data incorrect at index %d: %f (expected %f)\n",
+			t.Fatalf("Clone data incorrect at index %d: %f (expected %f)\n",
 				i, cloneData[i], originalData[i])
-			t.FailNow()
 		}
 	}
 	cloneData[2] = 1337
 	if originalData[2] != 3 {
-		t.Logf("Modifying clone data effected the original.\n")
-		t.FailNow()
+		t.Fatalf("Modifying clone data effected the original.\n")
 	}
 }
 
@@ -291,8 +271,7 @@ func TestZeroTensorContents(t *testing.T) {
 	a.ZeroContents()
 	for i, v := range data {
 		if v != 0.0 {
-			t.Logf("a[%d] = %f, expected it to be set to 0.\n", i, v)
-			t.FailNow()
+			t.Fatalf("a[%d] = %f, expected it to be set to 0.\n", i, v)
 		}
 	}
 
@@ -301,8 +280,7 @@ func TestZeroTensorContents(t *testing.T) {
 	customData := randomBytes(123, 2*shape.FlattenedSize())
 	b, e := NewCustomDataTensor(shape, customData, TensorElementDataTypeUint16)
 	if e != nil {
-		t.Logf("Error creating custom data tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating custom data tensor: %s\n", e)
 	}
 	defer b.Destroy()
 	for i := range customData {
@@ -314,8 +292,7 @@ func TestZeroTensorContents(t *testing.T) {
 	b.ZeroContents()
 	for i, v := range customData {
 		if v != 0 {
-			t.Logf("b[%d] = %d, expected it to be set to 0.\n", i, v)
-			t.FailNow()
+			t.Fatalf("b[%d] = %d, expected it to be set to 0.\n", i, v)
 		}
 	}
 }
@@ -334,32 +311,28 @@ func TestEmptyONNXFiles(t *testing.T) {
 	if e == nil {
 		// Really we're checking for a panic due to the empty slice, rather
 		// than a nil error.
-		t.Logf("Didn't get expected error when creating session.\n")
-		t.FailNow()
+		t.Fatalf("Didn't get expected error when creating session.\n")
 	}
 	t.Logf("Got expected error creating session with no ONNX content: %s\n", e)
 	_, e = NewDynamicAdvancedSessionWithONNXData([]byte{}, inputNames,
 		outputNames, nil)
 	if e == nil {
-		t.Logf("Didn't get expected error when creating dynamic advanced " +
+		t.Fatalf("Didn't get expected error when creating dynamic advanced " +
 			"session.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when creating dynamic session with no ONNX "+
 		"content: %s\n", e)
 	_, _, e = GetInputOutputInfoWithONNXData([]byte{})
 	if e == nil {
-		t.Logf("Didn't get expected error when getting input/output info " +
+		t.Fatalf("Didn't get expected error when getting input/output info " +
 			"with no ONNX content.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when getting input/output info with no "+
 		"ONNX content: %s\n", e)
 	_, e = GetModelMetadataWithONNXData([]byte{})
 	if e == nil {
-		t.Logf("Didn't get expected error when getting metadata with no " +
+		t.Fatalf("Didn't get expected error when getting metadata with no " +
 			"ONNX content.\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when getting metadata with no ONNX "+
 		"content: %s\n", e)
@@ -374,8 +347,7 @@ func TestExampleNetwork(t *testing.T) {
 	inputTensor, e := NewTensor(Shape(inputs.InputShape),
 		inputs.FlattenedInput)
 	if e != nil {
-		t.Logf("Failed creating input tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed creating input tensor: %s\n", e)
 	}
 	defer inputTensor.Destroy()
 	outputTensor := newTestTensor[float32](t, Shape(inputs.OutputShape))
@@ -386,19 +358,17 @@ func TestExampleNetwork(t *testing.T) {
 		[]string{"1x4 Input Vector"}, []string{"1x2 Output Vector"},
 		[]*Tensor[float32]{inputTensor}, []*Tensor[float32]{outputTensor})
 	if e != nil {
-		t.Logf("Failed creating session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed creating session: %s\n", e)
 	}
 	defer session.Destroy()
 	e = session.Run()
 	if e != nil {
-		t.Logf("Failed to run the session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed to run the session: %s\n", e)
 	}
 	e = floatsEqual(outputTensor.GetData(), inputs.FlattenedOutput)
 	if e != nil {
-		t.Logf("The neural network didn't produce the correct result: %s\n", e)
-		t.FailNow()
+		t.Fatalf("The neural network didn't produce the correct result: %s\n",
+			e)
 	}
 }
 
@@ -411,8 +381,7 @@ func TestExampleNetworkDynamic(t *testing.T) {
 	inputTensor, e := NewTensor(Shape(inputs.InputShape),
 		inputs.FlattenedInput)
 	if e != nil {
-		t.Logf("Failed creating input tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed creating input tensor: %s\n", e)
 	}
 	defer inputTensor.Destroy()
 	outputTensor := newTestTensor[float32](t, Shape(inputs.OutputShape))
@@ -422,20 +391,17 @@ func TestExampleNetworkDynamic(t *testing.T) {
 	session, e := NewDynamicSession[float32, float32]("test_data/example_network.onnx",
 		[]string{"1x4 Input Vector"}, []string{"1x2 Output Vector"})
 	if e != nil {
-		t.Logf("Failed creating session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed creating session: %s\n", e)
 	}
 	defer session.Destroy()
 	// running with the input
 	e = session.Run([]*Tensor[float32]{inputTensor}, []*Tensor[float32]{outputTensor})
 	if e != nil {
-		t.Logf("Failed to run the session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed to run the session: %s\n", e)
 	}
 	e = floatsEqual(outputTensor.GetData(), inputs.FlattenedOutput)
 	if e != nil {
-		t.Logf("The neural network didn't produce the correct result: %s\n", e)
-		t.FailNow()
+		t.Fatalf("The network didn't produce the correct result: %s\n", e)
 	}
 }
 
@@ -445,19 +411,16 @@ func TestEnableDisableTelemetry(t *testing.T) {
 
 	e := EnableTelemetry()
 	if e != nil {
-		t.Logf("Error enabling onnxruntime telemetry: %s\n", e)
-		t.Fail()
+		t.Errorf("Error enabling onnxruntime telemetry: %s\n", e)
 	}
 	e = DisableTelemetry()
 	if e != nil {
-		t.Logf("Error disabling onnxruntime telemetry: %s\n", e)
-		t.Fail()
+		t.Errorf("Error disabling onnxruntime telemetry: %s\n", e)
 	}
 	e = EnableTelemetry()
 	if e != nil {
-		t.Logf("Error re-enabling onnxruntime telemetry after disabling: %s\n",
-			e)
-		t.Fail()
+		t.Errorf("Error re-enabling onnxruntime telemetry after "+
+			"disabling: %s\n", e)
 	}
 }
 
@@ -468,20 +431,17 @@ func TestArbitraryTensors(t *testing.T) {
 	tensorShape := NewShape(2, 2)
 	tensorA, e := NewTensor(tensorShape, []uint8{1, 2, 3, 4})
 	if e != nil {
-		t.Logf("Error creating uint8 tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating uint8 tensor: %s\n", e)
 	}
 	defer tensorA.Destroy()
 	tensorB, e := NewTensor(tensorShape, []float64{5, 6, 7, 8})
 	if e != nil {
-		t.Logf("Error creating float64 tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating float64 tensor: %s\n", e)
 	}
 	defer tensorB.Destroy()
 	tensorC, e := NewTensor(tensorShape, []int16{9, 10, 11, 12})
 	if e != nil {
-		t.Logf("Error creating int16 tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating int16 tensor: %s\n", e)
 	}
 	defer tensorC.Destroy()
 	tensorList := []ArbitraryTensor{tensorA, tensorB, tensorC}
@@ -502,8 +462,7 @@ func randomMultitypeInputs(t *testing.T, seed int64) (*Tensor[uint8],
 	inputB, e := NewEmptyTensor[float64](NewShape(1, 2, 2))
 	if e != nil {
 		inputA.Destroy()
-		t.Logf("Failed creating input B: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed creating input B: %s\n", e)
 	}
 	inputA.GetData()[0] = uint8(rng.Intn(256))
 	for i := 0; i < 4; i++ {
@@ -530,15 +489,13 @@ func verifyTensorData[T TensorData](t *testing.T, tensor *Tensor[T],
 	expectedContent []T) {
 	data := tensor.GetData()
 	if len(data) != len(expectedContent) {
-		t.Logf("Expected tensor to contain %d elements, but it contains %d.\n",
+		t.Fatalf("Expected tensor to contain %d elements, got %d elements.\n",
 			len(expectedContent), len(data))
-		t.FailNow()
 	}
 	for i, v := range expectedContent {
 		if v != data[i] {
-			t.Logf("Data mismatch at element index %d: expected %v, got %v\n",
-				i, v, data[i])
-			t.FailNow()
+			t.Fatalf("Data mismatch at index %d: expected %v, got %v\n", i, v,
+				data[i])
 		}
 	}
 }
@@ -562,14 +519,12 @@ func TestDifferentInputOutputTypes(t *testing.T) {
 		[]ArbitraryTensor{inputA, inputB},
 		[]ArbitraryTensor{outputA, outputB}, nil)
 	if e != nil {
-		t.Logf("Failed creating session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Failed creating session: %s\n", e)
 	}
 	defer session.Destroy()
 	e = session.Run()
 	if e != nil {
-		t.Logf("Error running session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error running session: %s\n", e)
 	}
 	expectedA, expectedB := getExpectedMultitypeOutputs(inputA, inputB)
 	verifyTensorData(t, outputA, expectedA)
@@ -617,8 +572,7 @@ func TestDynamicDifferentInputOutputTypes(t *testing.T) {
 		e = session.Run([]ArbitraryTensor{aInputs[i], bInputs[i]},
 			[]ArbitraryTensor{aOutputs[i], bOutputs[i]})
 		if e != nil {
-			t.Logf("Failed running session for test %d: %s\n", i, e)
-			t.FailNow()
+			t.Fatalf("Failed running session for test %d: %s\n", i, e)
 		}
 	}
 
@@ -637,38 +591,50 @@ func TestDynamicAllocatedOutputTensor(t *testing.T) {
 	InitializeRuntime(t)
 	defer CleanupRuntime(t)
 
-	session, err := NewDynamicAdvancedSession("test_data/example_multitype.onnx",
+	session, e := NewDynamicAdvancedSession("test_data/example_multitype.onnx",
 		[]string{"InputA", "InputB"}, []string{"OutputA", "OutputB"}, nil)
+	if e != nil {
+		t.Fatalf("Error creating session: %s\n", e)
+	}
 	defer session.Destroy()
 
 	// Actually create the inputs and run the tests.
 	aInput, bInput := randomMultitypeInputs(t, 999)
 	var outputs [2]ArbitraryTensor
-	err = session.Run([]ArbitraryTensor{aInput, bInput}, outputs[:])
-	if err != nil {
-		t.Logf("Failed running session: %s\n", err)
-		t.FailNow()
+	e = session.Run([]ArbitraryTensor{aInput, bInput}, outputs[:])
+	if e != nil {
+		t.Fatalf("Failed running session: %s\n", e)
 	}
+	defer func() {
+		for _, output := range outputs {
+			output.Destroy()
+		}
+	}()
 
 	expectedA, expectedB := getExpectedMultitypeOutputs(aInput, bInput)
-	if outputA, ok := outputs[0].(*Tensor[int16]); !ok {
-		t.Logf("Expected outputA to be of type %T, got of type %T\n", outputA, outputs[0])
-		t.FailNow()
-	} else if expectedShape := NewShape(1, 2, 2); !outputA.shape.Equals(expectedShape) {
-		t.Logf("Expected outputA to be of shape %s, got of shape %s\n", expectedShape, outputA.shape)
-		t.FailNow()
-	} else {
-		verifyTensorData(t, outputA, expectedA)
+	expectedShape := NewShape(1, 2, 2)
+	outputA, ok := outputs[0].(*Tensor[int16])
+	if !ok {
+		t.Fatalf("Expected outputA to be of type %T, got of type %T\n",
+			outputA, outputs[0])
 	}
-	if outputB, ok := outputs[1].(*Tensor[int64]); !ok {
-		t.Logf("Expected outputB to be of type %T, got of type %T\n", outputB, outputs[1])
-		t.FailNow()
-	} else if expectedShape := NewShape(1, 1, 1); !outputB.shape.Equals(expectedShape) {
-		t.Logf("Expected outputB to be of shape %s, got of shape %s\n", expectedShape, outputB.shape)
-		t.FailNow()
-	} else {
-		verifyTensorData(t, outputB, expectedB)
+	if !outputA.shape.Equals(expectedShape) {
+		t.Fatalf("Expected outputA to be of shape %s, got of shape %s\n",
+			expectedShape, outputA.shape)
 	}
+	verifyTensorData(t, outputA, expectedA)
+
+	outputB, ok := outputs[1].(*Tensor[int64])
+	expectedShape = NewShape(1, 1, 1)
+	if !ok {
+		t.Fatalf("Expected outputB to be of type %T, got of type %T\n",
+			outputB, outputs[1])
+	}
+	if !outputB.shape.Equals(expectedShape) {
+		t.Fatalf("Expected outputB to be of shape %s, got of shape %s\n",
+			expectedShape, outputB.shape)
+	}
+	verifyTensorData(t, outputB, expectedB)
 }
 
 // Makes sure that the sum of each vector in the input tensor matches the
@@ -684,17 +650,14 @@ func checkVectorSum(input *Tensor[float32], output *Tensor[float32],
 	inputShape := input.GetShape()
 	outputShape := output.GetShape()
 	if len(inputShape) != 2 {
-		t.Logf("Expected a 2-dimensional input shape, got %v\n", inputShape)
-		t.FailNow()
+		t.Fatalf("Expected a 2-dimensional input shape, got %v\n", inputShape)
 	}
 	if len(outputShape) != 1 {
-		t.Logf("Expected 1-dimensional output shape, got %v\n", outputShape)
-		t.FailNow()
+		t.Fatalf("Expected 1-dimensional output shape, got %v\n", outputShape)
 	}
 	if inputShape[0] != outputShape[0] {
-		t.Logf("Input and output batch dimensions don't match (%d vs %d)\n",
+		t.Fatalf("Input and output batch dimensions don't match (%d vs %d)\n",
 			inputShape[0], outputShape[0])
-		t.FailNow()
 	}
 
 	// Compute the sums in Go
@@ -712,8 +675,7 @@ func checkVectorSum(input *Tensor[float32], output *Tensor[float32],
 
 	e := floatsEqual(expectedSums, output.GetData())
 	if e != nil {
-		t.Logf("ONNX-produced sums don't match CPU-produced sums: %s\n", e)
-		t.FailNow()
+		t.Fatalf("ONNX-produced sums don't match CPU-produced sums: %s\n", e)
 	}
 }
 
@@ -725,8 +687,7 @@ func TestDynamicInputOutputAxes(t *testing.T) {
 	session, e := NewDynamicAdvancedSession(netPath,
 		[]string{"input_vectors"}, []string{"output_scalars"}, nil)
 	if e != nil {
-		t.Logf("Error loading %s: %s\n", netPath, e)
-		t.FailNow()
+		t.Fatalf("Error loading %s: %s\n", netPath, e)
 	}
 	defer session.Destroy()
 	rng := rand.New(rand.NewSource(1234))
@@ -741,9 +702,8 @@ func TestDynamicInputOutputAxes(t *testing.T) {
 		inputShape := NewShape(int64(i), 10)
 		input, e := NewTensor(inputShape, dataBuffer)
 		if e != nil {
-			t.Logf("Error creating input tensor with shape %v: %s\n",
+			t.Fatalf("Error creating input tensor with shape %v: %s\n",
 				inputShape, e)
-			t.FailNow()
 		}
 
 		// Populate the input with new random floats.
@@ -757,8 +717,8 @@ func TestDynamicInputOutputAxes(t *testing.T) {
 		e = session.Run([]ArbitraryTensor{input}, outputs)
 		if e != nil {
 			input.Destroy()
-			t.Logf("Error running the session with batch size %d: %s\n", i, e)
-			t.FailNow()
+			t.Fatalf("Error running the session with batch size %d: %s\n",
+				i, e)
 		}
 
 		// The checkVectorSum function will destroy the input and output tensor
@@ -792,18 +752,16 @@ func TestWrongInputs(t *testing.T) {
 	e = session.Run([]ArbitraryTensor{inputA, inputB},
 		[]ArbitraryTensor{wrongTypeTensor, outputB})
 	if e == nil {
-		t.Logf("Didn't get expected error when passing a float32 tensor in " +
-			"place of an int16 output tensor.\n")
-		t.FailNow()
+		t.Fatalf("Didn't get expected error when passing a float32 tensor in" +
+			" place of an int16 output tensor.\n")
 	}
 	t.Logf("Got expected error when passing a float32 tensor in place of an "+
 		"int16 output tensor: %s\n", e)
 	e = session.Run([]ArbitraryTensor{inputA, wrongTypeTensor},
 		[]ArbitraryTensor{outputA, outputB})
 	if e == nil {
-		t.Logf("Didn't get expected error when passing a float32 tensor in " +
-			"place of a float64 input tensor.\n")
-		t.FailNow()
+		t.Fatalf("Didn't get expected error when passing a float32 tensor in" +
+			" place of a float64 input tensor.\n")
 	}
 	t.Logf("Got expected error when passing a float32 tensor in place of a "+
 		"float64 input tensor: %s\n", e)
@@ -816,9 +774,8 @@ func TestWrongInputs(t *testing.T) {
 	e = session.Run([]ArbitraryTensor{wrongShapeInput, inputB},
 		[]ArbitraryTensor{outputA, outputB})
 	if e == nil {
-		t.Logf("Didn't get expected error when running with an incorrectly " +
-			"shaped input.\n")
-		t.FailNow()
+		t.Fatalf("Didn't get expected error when running with an incorrectly" +
+			" shaped input.\n")
 	}
 	t.Logf("Got expected error when running with an incorrectly shaped "+
 		"input: %s\n", e)
@@ -827,9 +784,8 @@ func TestWrongInputs(t *testing.T) {
 	e = session.Run([]ArbitraryTensor{inputA, inputB},
 		[]ArbitraryTensor{outputA, wrongShapeOutput})
 	if e == nil {
-		t.Logf("Didn't get expected error when running with an incorrectly " +
-			"shaped output.\n")
-		t.FailNow()
+		t.Fatalf("Didn't get expected error when running with an incorrectly" +
+			" shaped output.\n")
 	}
 	t.Logf("Got expected error when running with an incorrectly shaped "+
 		"output: %s\n", e)
@@ -837,9 +793,8 @@ func TestWrongInputs(t *testing.T) {
 	e = session.Run([]ArbitraryTensor{inputA, inputB},
 		[]ArbitraryTensor{outputA, outputB})
 	if e != nil {
-		t.Logf("Got error attempting to (correctly) Run a session after "+
+		t.Fatalf("Got error attempting to (correctly) Run a session after "+
 			"attempting to use incorrect inputs or outputs: %s\n", e)
-		t.FailNow()
 	}
 }
 
@@ -849,16 +804,13 @@ func TestGetInputOutputInfo(t *testing.T) {
 	file := "test_data/example_several_inputs_and_outputs.onnx"
 	inputs, outputs, e := GetInputOutputInfo(file)
 	if e != nil {
-		t.Logf("Error getting input and output info for %s: %s\n", file, e)
-		t.FailNow()
+		t.Fatalf("Error getting input and output info for %s: %s\n", file, e)
 	}
 	if len(inputs) != 3 {
-		t.Logf("Expected 3 inputs, got %d\n", len(inputs))
-		t.FailNow()
+		t.Fatalf("Expected 3 inputs, got %d\n", len(inputs))
 	}
 	if len(outputs) != 2 {
-		t.Logf("Expected 2 outputs, got %d\n", len(outputs))
-		t.FailNow()
+		t.Fatalf("Expected 2 outputs, got %d\n", len(outputs))
 	}
 	for i, v := range inputs {
 		t.Logf("Input %d: %s\n", i, &v)
@@ -868,38 +820,32 @@ func TestGetInputOutputInfo(t *testing.T) {
 	}
 
 	if outputs[1].Name != "output 2" {
-		t.Logf("Incorrect output 1 name: %s, expected \"output 2\"\n",
+		t.Errorf("Incorrect output 1 name: %s, expected \"output 2\"\n",
 			outputs[1].Name)
-		t.Fail()
 	}
 	expectedShape := NewShape(1, 2, 3, 4, 5)
 	if !outputs[1].Dimensions.Equals(expectedShape) {
-		t.Logf("Incorrect output 1 shape: %s, expected %s\n",
+		t.Errorf("Incorrect output 1 shape: %s, expected %s\n",
 			outputs[1].Dimensions, expectedShape)
-		t.Fail()
 	}
 	var expectedType TensorElementDataType = TensorElementDataTypeDouble
 	if outputs[1].DataType != expectedType {
-		t.Logf("Incorrect output 1 data type: %s, expected %s\n",
+		t.Errorf("Incorrect output 1 data type: %s, expected %s\n",
 			outputs[1].DataType, expectedType)
-		t.Fail()
 	}
 	if inputs[0].Name != "input 1" {
-		t.Logf("Incorrect input 0 name: %s, expected \"input 1\"\n",
+		t.Errorf("Incorrect input 0 name: %s, expected \"input 1\"\n",
 			inputs[0].Name)
-		t.Fail()
 	}
 	expectedShape = NewShape(2, 5, 2, 5)
 	if !inputs[0].Dimensions.Equals(expectedShape) {
-		t.Logf("Incorrect input 0 shape: %s, expected %s\n",
+		t.Errorf("Incorrect input 0 shape: %s, expected %s\n",
 			inputs[0].Dimensions, expectedShape)
-		t.Fail()
 	}
 	expectedType = TensorElementDataTypeInt32
 	if inputs[0].DataType != expectedType {
-		t.Logf("Incorrect input 0 data type: %s, expected %s\n",
+		t.Errorf("Incorrect input 0 data type: %s, expected %s\n",
 			inputs[0].DataType, expectedType)
-		t.Fail()
 	}
 }
 
@@ -909,14 +855,12 @@ func TestModelMetadata(t *testing.T) {
 	file := "test_data/example_network.onnx"
 	metadata, e := GetModelMetadata(file)
 	if e != nil {
-		t.Logf("Error getting metadata for %s: %s\n", file, e)
-		t.FailNow()
+		t.Fatalf("Error getting metadata for %s: %s\n", file, e)
 	}
 	// We'll just test Destroy once; after this we won't check its return value
 	e = metadata.Destroy()
 	if e != nil {
-		t.Logf("Error destroying metadata: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error destroying metadata: %s\n", e)
 	}
 
 	// Try getting the metadata from a session instead of from a file.
@@ -927,93 +871,78 @@ func TestModelMetadata(t *testing.T) {
 	session, e := NewDynamicAdvancedSession(file, []string{"Input"},
 		[]string{"Output"}, nil)
 	if e != nil {
-		t.Logf("Error creating session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating session: %s\n", e)
 	}
 	defer session.Destroy()
 	metadata, e = session.GetModelMetadata()
 	if e != nil {
-		t.Logf("Error getting metadata from DynamicAdvancedSession: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error getting metadata from DynamicAdvancedSession: %s\n", e)
 	}
 	defer metadata.Destroy()
 	producerName, e := metadata.GetProducerName()
 	if e != nil {
-		t.Logf("Error getting producer name: %s\n", e)
-		t.Fail()
+		t.Errorf("Error getting producer name: %s\n", e)
 	} else {
 		t.Logf("Got producer name: %s\n", producerName)
 	}
 	graphName, e := metadata.GetGraphName()
 	if e != nil {
-		t.Logf("Error getting graph name: %s\n", e)
-		t.Fail()
+		t.Errorf("Error getting graph name: %s\n", e)
 	} else {
 		t.Logf("Got graph name: %s\n", graphName)
 	}
 	domainStr, e := metadata.GetDomain()
 	if e != nil {
-		t.Logf("Error getting domain: %s\n", e)
-		t.Fail()
+		t.Errorf("Error getting domain: %s\n", e)
 	} else {
 		t.Logf("Got domain: %s\n", domainStr)
 		if domainStr != "test domain" {
-			t.Logf("Incorrect domain string, expected \"test domain\"\n")
-			t.Fail()
+			t.Errorf("Incorrect domain string, expected \"test domain\"\n")
 		}
 	}
 	description, e := metadata.GetDescription()
 	if e != nil {
-		t.Logf("Error getting description: %s\n", e)
-		t.Fail()
+		t.Errorf("Error getting description: %s\n", e)
 	} else {
 		t.Logf("Got description: %s\n", description)
 	}
 	version, e := metadata.GetVersion()
 	if e != nil {
-		t.Logf("Error getting version: %s\n", e)
-		t.Fail()
+		t.Errorf("Error getting version: %s\n", e)
 	} else {
 		t.Logf("Got version: %d\n", version)
 		if version != 1337 {
-			t.Logf("Incorrect version number, expected 1337\n")
-			t.Fail()
+			t.Errorf("Incorrect version number, expected 1337\n")
 		}
 	}
 	mapKeys, e := metadata.GetCustomMetadataMapKeys()
 	if e != nil {
-		t.Logf("Error getting custom metadata keys: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error getting custom metadata keys: %s\n", e)
 	}
 	t.Logf("Got %d custom metadata map keys.\n", len(mapKeys))
 	if len(mapKeys) != 2 {
-		t.Logf("Incorrect number of custom metadata keys, expected 2")
-		t.Fail()
+		t.Errorf("Incorrect number of custom metadata keys, expected 2")
 	}
 	for _, k := range mapKeys {
 		value, present, e := metadata.LookupCustomMetadataMap(k)
 		if e != nil {
-			t.Logf("Error looking up key %s in custom metadata: %s\n", k, e)
-			t.Fail()
+			t.Errorf("Error looking up key %s in custom metadata: %s\n", k, e)
 		} else {
 			if !present {
-				t.Logf("LookupCustomMetadataMap didn't return true for a " +
+				t.Errorf("LookupCustomMetadataMap didn't return true for a " +
 					"key that should be present in the map\n")
-				t.Fail()
 			}
 			t.Logf("  Metadata key \"%s\" = \"%s\"\n", k, value)
 		}
 	}
 	badValue, present, e := metadata.LookupCustomMetadataMap("invalid key")
 	if len(badValue) != 0 {
-		t.Logf("Didn't get an empty string when looking up an invalid "+
+		t.Fatalf("Didn't get an empty string when looking up an invalid "+
 			"metadata key, got \"%s\" instead\n", badValue)
-		t.FailNow()
 	}
 	if present {
-		t.Logf("LookupCustomMetadataMap didn't return false for a key that " +
-			"isn't in the map\n")
-		t.Fail()
+		t.Errorf("LookupCustomMetadataMap didn't return false for a key that" +
+			" isn't in the map\n")
 	}
 	// Tossing in this check, since the docs aren't clear on this topic. (The
 	// docs specify returning an empty string, but do not mention a non-NULL
@@ -1043,38 +972,32 @@ func TestCustomDataTensors(t *testing.T) {
 	// it works this way, too.
 	v, e := NewCustomDataTensor(shape, tensorData, TensorElementDataTypeUint16)
 	if e != nil {
-		t.Logf("Error creating uint16 CustomDataTensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating uint16 CustomDataTensor: %s\n", e)
 	}
 	shape[0] = 6
 	if v.GetShape().Equals(shape) {
-		t.Logf("CustomDataTensor didn't correctly create a Clone of its shape")
-		t.FailNow()
+		t.Fatalf("CustomDataTensor didn't properly clone its shape")
 	}
 	e = v.Destroy()
 	if e != nil {
-		t.Logf("Error destroying CustomDataTensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error destroying CustomDataTensor: %s\n", e)
 	}
 	tensorData = randomBytes(1234, 2*shape.FlattenedSize())
 	v, e = NewCustomDataTensor(shape, tensorData, TensorElementDataTypeFloat16)
 	if e != nil {
-		t.Logf("Error creating float16 tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating float16 tensor: %s\n", e)
 	}
 	e = v.Destroy()
 	if e != nil {
-		t.Logf("Error destroying float16 tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error destroying float16 tensor: %s\n", e)
 	}
 	// Make sure we don't fail if providing more data than necessary
 	shape[0] = 1
 	v, e = NewCustomDataTensor(shape, tensorData,
 		TensorElementDataTypeBFloat16)
 	if e != nil {
-		t.Logf("Got error when creating a tensor with more data than "+
+		t.Fatalf("Got error when creating a tensor with more data than "+
 			"necessary: %s\n", e)
-		t.FailNow()
 	}
 	v.Destroy()
 
@@ -1083,9 +1006,8 @@ func TestCustomDataTensors(t *testing.T) {
 	v, e = NewCustomDataTensor(shape, tensorData, TensorElementDataTypeFloat16)
 	if e == nil {
 		v.Destroy()
-		t.Logf("Didn't get error when creating custom tensor with an " +
+		t.Fatalf("Didn't get error when creating custom tensor with an " +
 			"invalid shape\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error creating tensor with invalid shape: %s\n", e)
 	shape = NewShape(1, 2, 3, 4, 5)
@@ -1093,9 +1015,8 @@ func TestCustomDataTensors(t *testing.T) {
 	v, e = NewCustomDataTensor(shape, tensorData, TensorElementDataTypeUint8)
 	if e == nil {
 		v.Destroy()
-		t.Logf("Didn't get error when creating custom tensor with too " +
+		t.Fatalf("Didn't get error when creating custom tensor with too " +
 			"little data\n")
-		t.FailNow()
 	}
 	t.Logf("Got expected error when creating custom data tensor with "+
 		"too little data: %s\n", e)
@@ -1106,8 +1027,7 @@ func TestCustomDataTensors(t *testing.T) {
 	v, e = NewCustomDataTensor(NewShape(2), tensorData, badType)
 	if e == nil {
 		v.Destroy()
-		t.Logf("Didn't get error when creating custom tensor with bad type\n")
-		t.FailNow()
+		t.Fatalf("Didn't get error when creating tensor with bad type\n")
 	}
 	t.Logf("Got expected error when creating custom data tensor with bad "+
 		"type: %s\n", e)
@@ -1143,15 +1063,13 @@ func TestFloat16Network(t *testing.T) {
 	inputTensor, e := NewCustomDataTensor(NewShape(1, 2, 2, 2), inputData,
 		TensorElementDataTypeFloat16)
 	if e != nil {
-		t.Logf("Error creating input tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating input tensor: %s\n", e)
 	}
 	defer inputTensor.Destroy()
 	outputTensor, e := NewCustomDataTensor(NewShape(1, 2, 2, 2), outputData,
 		TensorElementDataTypeBFloat16)
 	if e != nil {
-		t.Logf("Error creating output tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating output tensor: %s\n", e)
 	}
 	defer outputTensor.Destroy()
 
@@ -1159,20 +1077,17 @@ func TestFloat16Network(t *testing.T) {
 		[]string{"InputA"}, []string{"OutputA"},
 		[]ArbitraryTensor{inputTensor}, []ArbitraryTensor{outputTensor}, nil)
 	if e != nil {
-		t.Logf("Error creating session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating session: %s\n", e)
 	}
 	defer session.Destroy()
 	e = session.Run()
 	if e != nil {
-		t.Logf("Error running session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error running session: %s\n", e)
 	}
 	for i := range outputData {
 		if outputData[i] != expectedOutput[i] {
-			t.Logf("Incorrect output byte at index %d: 0x%02x (expected "+
+			t.Fatalf("Incorrect output byte at index %d: 0x%02x (expected "+
 				"0x%02x)\n", i, outputData[i], expectedOutput[i])
-			t.FailNow()
 		}
 	}
 }
@@ -1189,14 +1104,12 @@ func prepareBenchmarkTensors(t testing.TB, seed int64) (*Tensor[float32],
 	}
 	input, e := NewTensor(NewShape(1, vectorLength), inputData)
 	if e != nil {
-		t.Logf("Error creating input tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating input tensor: %s\n", e)
 	}
 	output, e := NewEmptyTensor[float32](NewShape(1, vectorLength))
 	if e != nil {
 		input.Destroy()
-		t.Logf("Error creating output tensor: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating output tensor: %s\n", e)
 	}
 	return input, output
 }
@@ -1213,14 +1126,12 @@ func testBigSessionWithOptions(t *testing.T, options *SessionOptions) {
 		[]string{"Input"}, []string{"Output"}, []ArbitraryTensor{input},
 		[]ArbitraryTensor{output}, options)
 	if e != nil {
-		t.Logf("Error creating session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating session: %s\n", e)
 	}
 	defer session.Destroy()
 	e = session.Run()
 	if e != nil {
-		t.Logf("Error running the session: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error running the session: %s\n", e)
 	}
 }
 
@@ -1237,16 +1148,14 @@ func benchmarkBigSessionWithOptions(b *testing.B, options *SessionOptions) {
 		[]string{"Input"}, []string{"Output"}, []ArbitraryTensor{input},
 		[]ArbitraryTensor{output}, options)
 	if e != nil {
-		b.Logf("Error creating session: %s\n", e)
-		b.FailNow()
+		b.Fatalf("Error creating session: %s\n", e)
 	}
 	defer session.Destroy()
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
 		e = session.Run()
 		if e != nil {
-			b.Logf("Error running iteration %d/%d: %s\n", n+1, b.N, e)
-			b.FailNow()
+			b.Fatalf("Error running iteration %d/%d: %s\n", n+1, b.N, e)
 		}
 	}
 }
@@ -1256,29 +1165,24 @@ func TestSessionOptions(t *testing.T) {
 	defer CleanupRuntime(t)
 	options, e := NewSessionOptions()
 	if e != nil {
-		t.Logf("Error creating session options: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating session options: %s\n", e)
 	}
 	defer options.Destroy()
 	e = options.SetIntraOpNumThreads(3)
 	if e != nil {
-		t.Logf("Error setting intra-op num threads: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error setting intra-op num threads: %s\n", e)
 	}
 	e = options.SetInterOpNumThreads(1)
 	if e != nil {
-		t.Logf("Error setting inter-op num threads: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error setting inter-op num threads: %s\n", e)
 	}
 	e = options.SetCpuMemArena(true)
 	if e != nil {
-		t.Logf("Error setting CPU memory arena: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error setting CPU memory arena: %s\n", e)
 	}
 	e = options.SetMemPattern(true)
 	if e != nil {
-		t.Logf("Error setting memory pattern: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error setting memory pattern: %s\n", e)
 	}
 	testBigSessionWithOptions(t, options)
 }
@@ -1291,19 +1195,16 @@ func runNumThreadsBenchmark(b *testing.B, nThreads int) {
 	defer CleanupRuntime(b)
 	options, e := NewSessionOptions()
 	if e != nil {
-		b.Logf("Error creating options: %s\n", e)
-		b.FailNow()
+		b.Fatalf("Error creating options: %s\n", e)
 	}
 	defer options.Destroy()
 	e = options.SetIntraOpNumThreads(nThreads)
 	if e != nil {
-		b.Logf("Error setting intra-op threads to %d: %s\n", nThreads, e)
-		b.FailNow()
+		b.Fatalf("Error setting intra-op threads to %d: %s\n", nThreads, e)
 	}
 	e = options.SetInterOpNumThreads(nThreads)
 	if e != nil {
-		b.Logf("Error setting inter-op threads to %d: %s\n", nThreads, e)
-		b.FailNow()
+		b.Fatalf("Error setting inter-op threads to %d: %s\n", nThreads, e)
 	}
 	benchmarkBigSessionWithOptions(b, options)
 }
@@ -1346,14 +1247,12 @@ func getCUDASessionOptions(t testing.TB) *SessionOptions {
 	// Next, provide the CUDA options to the sesison options
 	sessionOptions, e := NewSessionOptions()
 	if e != nil {
-		t.Logf("Error creating SessionOptions: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating SessionOptions: %s\n", e)
 	}
 	e = sessionOptions.AppendExecutionProviderCUDA(cudaOptions)
 	if e != nil {
 		sessionOptions.Destroy()
-		t.Logf("Error setting CUDA execution provider options: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error setting CUDA execution provider options: %s\n", e)
 	}
 	return sessionOptions
 }
@@ -1396,14 +1295,12 @@ func getTensorRTSessionOptions(t testing.TB) *SessionOptions {
 	}
 	sessionOptions, e := NewSessionOptions()
 	if e != nil {
-		t.Logf("Error creating SessionOptions: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating SessionOptions: %s\n", e)
 	}
 	e = sessionOptions.AppendExecutionProviderTensorRT(trtOptions)
 	if e != nil {
 		sessionOptions.Destroy()
-		t.Logf("Error setting TensorRT execution provider: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error setting TensorRT execution provider: %s\n", e)
 	}
 	return sessionOptions
 }
@@ -1428,8 +1325,7 @@ func BenchmarkTensorRTSession(b *testing.B) {
 func getCoreMLSessionOptions(t testing.TB) *SessionOptions {
 	options, e := NewSessionOptions()
 	if e != nil {
-		t.Logf("Error creating session options: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating session options: %s\n", e)
 	}
 	e = options.AppendExecutionProviderCoreML(0)
 	if e != nil {
@@ -1460,8 +1356,7 @@ func BenchmarkCoreMLSession(b *testing.B) {
 func getDirectMLSessionOptions(t testing.TB) *SessionOptions {
 	options, e := NewSessionOptions()
 	if e != nil {
-		t.Logf("Error creating session options: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating session options: %s\n", e)
 	}
 	e = options.AppendExecutionProviderDirectML(0)
 	if e != nil {
@@ -1493,8 +1388,7 @@ func BenchmarkDirectMLSession(b *testing.B) {
 func getOpenVINOSessionOptions(t testing.TB) *SessionOptions {
 	options, e := NewSessionOptions()
 	if e != nil {
-		t.Logf("Error creating session options: %s\n", e)
-		t.FailNow()
+		t.Fatalf("Error creating session options: %s\n", e)
 	}
 	e = options.AppendExecutionProviderOpenVINO(map[string]string{})
 	if e != nil {

--- a/onnxruntime_training_go.go
+++ b/onnxruntime_training_go.go
@@ -52,8 +52,8 @@ func (t *Scalar[T]) DataType() C.ONNXTensorElementDataType {
 	return GetTensorElementDataType[T]()
 }
 
-func (t *Scalar[_]) GetInternals() *TensorInternalData {
-	return &TensorInternalData{
+func (t *Scalar[_]) GetInternals() *ValueInternalData {
+	return &ValueInternalData{
 		ortValue: t.ortValue,
 	}
 }
@@ -485,14 +485,14 @@ func createCtrainingSessionWithPaths(checkpointState *C.OrtCheckpointState,
 
 // NewTrainingSessionWithOnnxData is like NewTrainingSession, but it accepts
 // bytes rather than paths to the training assets. Note that there does not
-// seem to currently be a way to export the trained model from a session instantiated
-// from bytes. If you wish to export the trained model, you should use NewTrainingSession
-// instead.
+// seem to currently be a way to export the trained model from a session
+// instantiated from bytes. If you wish to export the trained model, you should
+// use NewTrainingSession instead.
 func NewTrainingSessionWithOnnxData(checkpointData []byte,
 	trainingData []byte,
 	evalData []byte,
 	optimizerData []byte,
-	inputs []ArbitraryTensor, outputs []ArbitraryTensor,
+	inputs, outputs []Value,
 	options *SessionOptions) (*TrainingSession, error) {
 
 	if err := checkTraining(); err != nil {
@@ -540,7 +540,7 @@ func NewTrainingSessionWithOnnxData(checkpointData []byte,
 	}, nil
 }
 
-func validateInputOutputs(inputs, outputs []ArbitraryTensor) error {
+func validateInputOutputs(inputs, outputs []Value) error {
 	if len(inputs) == 0 {
 		return fmt.Errorf("inputs must have length greater than zero")
 	}
@@ -558,8 +558,7 @@ func NewTrainingSession(checkpointStatePath string,
 	trainingModelPath string,
 	evalModelPath string,
 	optimizerModelPath string,
-	inputs,
-	outputs []ArbitraryTensor,
+	inputs, outputs []Value,
 	options *SessionOptions) (*TrainingSession, error) {
 
 	if err := checkTraining(); err != nil {

--- a/onnxruntime_training_go.go
+++ b/onnxruntime_training_go.go
@@ -58,6 +58,10 @@ func (t *Scalar[_]) GetInternals() *TensorInternalData {
 	}
 }
 
+func (t *Scalar[_]) GetONNXType() ONNXType {
+	return ONNXTypeTensor
+}
+
 // NewEmptyScalar creates a new scalar of type T.
 func NewEmptyScalar[T TensorData]() (*Scalar[T], error) {
 	var data T

--- a/onnxruntime_training_test.go
+++ b/onnxruntime_training_test.go
@@ -192,7 +192,7 @@ func TestTraining(t *testing.T) {
 		path.Join(trainingArtifactsFolder, "training_model.onnx"),
 		path.Join(trainingArtifactsFolder, "eval_model.onnx"),
 		path.Join(trainingArtifactsFolder, "optimizer_model.onnx"),
-		[]ArbitraryTensor{batchInputTensor, batchTargetTensor}, []ArbitraryTensor{lossScalar},
+		[]Value{batchInputTensor, batchTargetTensor}, []Value{lossScalar},
 		nil)
 
 	if errorSessionCreation != nil {
@@ -200,7 +200,7 @@ func TestTraining(t *testing.T) {
 	}
 
 	// cleanup after test run
-	defer func(session *TrainingSession, tensors []ArbitraryTensor) {
+	defer func(session *TrainingSession, tensors []Value) {
 		var errs []error
 		errs = append(errs, session.Destroy())
 		for _, t := range tensors {
@@ -209,7 +209,7 @@ func TestTraining(t *testing.T) {
 		if e := errors.Join(errs...); e != nil {
 			t.Fatalf("cleanup of test failed with error: %v", e)
 		}
-	}(trainingSession, []ArbitraryTensor{batchInputTensor, batchTargetTensor, lossScalar})
+	}(trainingSession, []Value{batchInputTensor, batchTargetTensor, lossScalar})
 
 	losses := []float32{}
 	epochs := 100
@@ -300,7 +300,7 @@ func TestTraining(t *testing.T) {
 	// (we care about correctness more than generalization here)
 	session, err := NewAdvancedSession(path.Join("test_data", "training_test", "final_inference.onnx"),
 		[]string{"input"}, []string{"output"},
-		[]ArbitraryTensor{batchInputTensor}, []ArbitraryTensor{batchTargetTensor}, nil)
+		[]Value{batchInputTensor}, []Value{batchTargetTensor}, nil)
 
 	if err != nil {
 		t.Fatalf("creation of inference session failed with error: %v", err)

--- a/onnxruntime_training_test.go
+++ b/onnxruntime_training_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"path"
 	"testing"
 )
@@ -271,16 +272,29 @@ func TestTraining(t *testing.T) {
 	}
 
 	// test the saving of the checkpoint state
-	errSaveCheckpoint := trainingSession.SaveCheckpoint(path.Join("test_data", "training_test", "finalCheckpoint"), false)
+	finalCheckpointPath := path.Join("test_data", "training_test", "finalCheckpoint")
+	errSaveCheckpoint := trainingSession.SaveCheckpoint(finalCheckpointPath, false)
 	if errSaveCheckpoint != nil {
 		t.Fatalf("Saving of checkpoint failed with error: %v", errSaveCheckpoint)
 	}
 
 	// test the saving of the model
-	errExport := trainingSession.ExportModel(path.Join("test_data", "training_test", "final_inference.onnx"), []string{"output"})
+	finalModelPath := path.Join("test_data", "training_test", "final_inference.onnx")
+	errExport := trainingSession.ExportModel(finalModelPath, []string{"output"})
 	if errExport != nil {
 		t.Fatalf("Exporting model failed with error: %v", errExport)
 	}
+
+	defer func() {
+		e := os.Remove(finalCheckpointPath)
+		if e != nil {
+			t.Errorf("Error removing final checkpoint file %s: %s", finalCheckpointPath, e)
+		}
+		e = os.Remove(finalModelPath)
+		if e != nil {
+			t.Errorf("Error removing final model file %s: %s", finalModelPath, e)
+		}
+	}()
 
 	// load the model back in and test in-sample predictions for the first batch
 	// (we care about correctness more than generalization here)


### PR DESCRIPTION
 - This should address issue #60

 - The largest change in terms of LoC is replacing a large amount of `t.Logf`+`t.FailNow` with `t.Fatalf` in `onnxruntime_test.go`.

 - The change with the most importance moving forward is replacing `ArbitraryTensor` with `Value`, which already saves a lot of typing.  `ArbitraryTensor` remains as an alias for backwards compatibility.

 - The new `Value` type is in preparation to start adding support for non-Tensor types, in response to issue #57.