### PR TITLE
Allow Tensor[bool] types

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -950,7 +950,7 @@ func NewScalar[T TensorData](data T) (*Scalar[T], error) {
 	dataSize := unsafe.Sizeof(dataSlice[0]) * uintptr(1)
 
 	status := C.CreateOrtTensorWithShape(unsafe.Pointer(&dataSlice[0]),
-	C.size_t(dataSize), nil, C.int64_t(0), ortMemoryInfo, dataType, &ortValue)
+		C.size_t(dataSize), nil, C.int64_t(0), ortMemoryInfo, dataType, &ortValue)
 	if status != nil {
 		return nil, statusToError(status)
 	}
@@ -961,7 +961,6 @@ func NewScalar[T TensorData](data T) (*Scalar[T], error) {
 	}
 	return &toReturn, nil
 }
-
 
 // Holds options required when enabling the CUDA backend for a session. This
 // struct wraps C onnxruntime types; users must create instances of this using
@@ -1733,10 +1732,11 @@ func (s *DynamicAdvancedSession) Destroy() error {
 	return s.s.Destroy()
 }
 
-func createTensorWithCData[T TensorData](shape Shape, data unsafe.Pointer) (*Tensor[T], error) {
-	totalSize := shape.FlattenedSize()
-	actualData := unsafe.Slice((*T)(data), totalSize)
-	dataCopy := make([]T, totalSize)
+func createTensorWithCData[T TensorData](shape Shape,
+	data unsafe.Pointer) (*Tensor[T], error) {
+	totalCount := shape.FlattenedSize()
+	actualData := unsafe.Slice((*T)(data), totalCount)
+	dataCopy := make([]T, totalCount)
 	copy(dataCopy, actualData)
 	return NewTensor[T](shape, dataCopy)
 }
@@ -1871,6 +1871,8 @@ func createTensorFromOrtValue(v *C.OrtValue) (Value, error) {
 		return createTensorWithCData[uint32](shape, tensorData)
 	case TensorElementDataTypeUint64:
 		return createTensorWithCData[uint64](shape, tensorData)
+	case TensorElementDataTypeBool:
+		return createTensorWithCData[bool](shape, tensorData)
 	default:
 		totalSize := shape.FlattenedSize()
 		actualData := unsafe.Slice((*byte)(tensorData), totalSize)

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -129,7 +129,7 @@ func TestCreateTensor(t *testing.T) {
 	}
 	defer tensor1.Destroy()
 	if len(tensor1.GetData()) != 6 {
-		t.Logf("Incorrect data length for tensor1: %d\n",
+		t.Fatalf("Incorrect data length for tensor1: %d\n",
 			len(tensor1.GetData()))
 	}
 	// Make sure that the underlying tensor created a copy of the shape we
@@ -164,6 +164,43 @@ func TestCreateTensor(t *testing.T) {
 	if len(tensor2.GetData()) != 10 {
 		t.Fatalf("New tensor data contains %d elements, when it should "+
 			"contain 10.\n", len(tensor2.GetData()))
+	}
+}
+
+func TestBoolTensor(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+	data := []bool{true, false, true, true}
+	tensor1, e := NewTensor(NewShape(4), data)
+	if e != nil {
+		t.Fatalf("Failed creating bool tensor: %s\n", e)
+	}
+	defer tensor1.Destroy()
+	if len(tensor1.GetData()) != 4 {
+		t.Fatalf("Incorrect data length for bool tensor: %d\n",
+			len(tensor1.GetData()))
+	}
+	if !tensor1.GetData()[3] {
+		t.Errorf("Expected tensor1[3] to be true; it wasn't.\n")
+	}
+	if tensor1.GetData()[1] {
+		t.Errorf("Expected tensor1[1] to be false; it wasn't.\n")
+	}
+	tensor1.ZeroContents()
+	for _, b := range data {
+		if b {
+			t.Errorf("Zeroing tensor1 didn't set its data slice to false.\n")
+		}
+	}
+	tensor2, e := NewEmptyTensor[bool](tensor1.GetShape())
+	if e != nil {
+		t.Fatalf("Error creating empty bool tensor: %s\n", e)
+	}
+	defer tensor2.Destroy()
+	for _, b := range tensor2.GetData() {
+		if b {
+			t.Errorf("A new empty bool tensor wasn't initialized to false.\n")
+		}
 	}
 }
 

--- a/tensor_type_constraints.go
+++ b/tensor_type_constraints.go
@@ -19,7 +19,7 @@ type IntData interface {
 
 // This is used as a type constraint for the generic Tensor type.
 type TensorData interface {
-	FloatData | IntData
+	FloatData | IntData | ~bool
 }
 
 // Returns the ONNX enum value used to indicate TensorData type T.
@@ -49,6 +49,8 @@ func GetTensorElementDataType[T TensorData]() C.ONNXTensorElementDataType {
 		return C.ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64
 	case reflect.Uint64:
 		return C.ONNX_TENSOR_ELEMENT_DATA_TYPE_UINT64
+	case reflect.Bool:
+		return C.ONNX_TENSOR_ELEMENT_DATA_TYPE_BOOL
 	}
 	return C.ONNX_TENSOR_ELEMENT_DATA_TYPE_UNDEFINED
 }


### PR DESCRIPTION
With this, one should be able to write code like the following:
```go
data := []bool{false, true, false, true}
tensor, err := ort.NewTensor(NewShape(2, 2), data)
```

My main reservation is that Go may in the future represent bool slices by something other than single bytes. However, I doubt this will be the case for several reasons:

 1. It would likely break many other Cgo libraries
 2. It would make binary.Write and binary.Read more complicated, since both guarantee one byte per bool
 3. Go seems to have no mechanism to have elements of slices be non-byte sizes, which would be necessary for some slice-of-bits implementation of bool.
 4. There should never be a reason for a bool to be _larger_ than one byte.

Given these thoughts, I think it's reasonable to assume this change will be safe. If any of this changes in the future, it would require deprecating and removing bool tensor support, which hopefully won't be heavily used anyway.