### PR TITLE
Support Log Level Settings for ONNX Runtime Environment

### DIFF
--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -55,6 +55,10 @@ OrtStatus *CreateOrtEnv(char *name, OrtEnv **env) {
   return ort_api->CreateEnv(ORT_LOGGING_LEVEL_ERROR, name, env);
 }
 
+OrtStatus *UpdateEnvWithCustomLogLevel(OrtEnv *ort_env, OrtLoggingLevel log_severity_level) {
+  return ort_api->UpdateEnvWithCustomLogLevel(ort_env, log_severity_level);
+}
+
 OrtStatus *DisableTelemetry(OrtEnv *env) {
   return ort_api->DisableTelemetryEvents(env);
 }

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -48,6 +48,9 @@ void ReleaseOrtStatus(OrtStatus *status);
 // Wraps calling ort_api->CreateEnv. Returns a non-NULL status on error.
 OrtStatus *CreateOrtEnv(char *name, OrtEnv **env);
 
+// Wraps calling ort_api->UpdateEnvWithCustomLogLevel. Return a non-NULL status on error.
+OrtStatus *UpdateEnvWithCustomLogLevel(OrtEnv *ort_env, OrtLoggingLevel log_severity_level);
+
 // Wraps ort_api->DisableTelemetryEvents. Returns a non-NULL status on error.
 OrtStatus *DisableTelemetry(OrtEnv *env);
 


### PR DESCRIPTION
PR adds support for various logging levels (verbose, info, warning, error, fatal).  Currently, the module sets the log level to error (this PR doesn't change that default), but less severe messages are useful for a variety of purposes such as debugging and this PR allows adjustment the log level during initialization of the ORT environment.