### PR TITLE
Add CoreML provider with options

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -1415,150 +1415,9 @@ func (o *SessionOptions) AppendExecutionProviderTensorRT(
 	return nil
 }
 
-// CoreMLModelFormat represents the format of the CoreML model.
-type CoreMLModelFormat string
-
-const (
-	// CoreMLModelFormatMLProgram creates an MLProgram format model.
-	// Requires CoreML 5 or later (iOS 15+ or macOS 12+).
-	CoreMLModelFormatMLProgram CoreMLModelFormat = "MLProgram"
-
-	// CoreMLModelFormatNeuralNetwork creates a NeuralNetwork format model.
-	// Requires CoreML 3 or later (iOS 13+ or macOS 10.15+).
-	CoreMLModelFormatNeuralNetwork CoreMLModelFormat = "NeuralNetwork"
-)
-
-// CoreMLComputeUnits represents the compute units to use with CoreML.
-type CoreMLComputeUnits string
-
-const (
-	// CoreMLComputeUnitsCPUOnly limits CoreML to running on CPU only.
-	CoreMLComputeUnitsCPUOnly CoreMLComputeUnits = "CPUOnly"
-
-	// CoreMLComputeUnitsCPUAndNeuralEngine enables CoreML EP for Apple devices
-	// with a compatible Apple Neural Engine (ANE).
-	CoreMLComputeUnitsCPUAndNeuralEngine CoreMLComputeUnits = "CPUAndNeuralEngine"
-
-	// CoreMLComputeUnitsCPUAndGPU enables CoreML EP for Apple devices
-	// with a compatible GPU.
-	CoreMLComputeUnitsCPUAndGPU CoreMLComputeUnits = "CPUAndGPU"
-
-	// CoreMLComputeUnitsALL enables CoreML EP for all compatible Apple devices.
-	CoreMLComputeUnitsALL CoreMLComputeUnits = "ALL"
-)
-
-// CoreMLSpecializationStrategy represents the specialization strategy for CoreML models.
-type CoreMLSpecializationStrategy string
-
-const (
-	// CoreMLSpecializationStrategyDefault uses the default specialization strategy.
-	CoreMLSpecializationStrategyDefault CoreMLSpecializationStrategy = "Default"
-
-	// CoreMLSpecializationStrategyFastPrediction optimizes for prediction speed.
-	CoreMLSpecializationStrategyFastPrediction CoreMLSpecializationStrategy = "FastPrediction"
-)
-
-// CoreMLProviderOptions defines the options for the CoreML execution provider.
-type CoreMLProviderOptions struct {
-	// Internal map to store the options
-	options map[string]string
-}
-
-// NewCoreMLProviderOptions creates a new CoreMLProviderOptions with default values.
-func NewCoreMLProviderOptions() *CoreMLProviderOptions {
-	options := &CoreMLProviderOptions{
-		options: make(map[string]string),
-	}
-
-	// Set default values
-	options.options["ModelFormat"] = string(CoreMLModelFormatNeuralNetwork)
-	options.options["MLComputeUnits"] = string(CoreMLComputeUnitsALL)
-	options.options["RequireStaticInputShapes"] = "0"
-	options.options["EnableOnSubgraphs"] = "0"
-	options.options["SpecializationStrategy"] = string(CoreMLSpecializationStrategyDefault)
-	options.options["ProfileComputePlan"] = "0"
-	options.options["AllowLowPrecisionAccumulationOnGPU"] = "0"
-
-	return options
-}
-
-// SetModelFormat sets the CoreML model format to use.
-// Default is CoreMLModelFormatNeuralNetwork.
-func (o *CoreMLProviderOptions) SetModelFormat(format CoreMLModelFormat) {
-	o.options["ModelFormat"] = string(format)
-}
-
-// SetMLComputeUnits specifies which compute units to enable.
-// Default is CoreMLComputeUnitsALL.
-func (o *CoreMLProviderOptions) SetMLComputeUnits(units CoreMLComputeUnits) {
-	o.options["MLComputeUnits"] = string(units)
-}
-
-// SetRequireStaticInputShapes when true only allows the CoreML EP to take nodes
-// with inputs that have static shapes.
-// Default is false.
-func (o *CoreMLProviderOptions) SetRequireStaticInputShapes(require bool) {
-	if require {
-		o.options["RequireStaticInputShapes"] = "1"
-	} else {
-		o.options["RequireStaticInputShapes"] = "0"
-	}
-}
-
-// SetEnableOnSubgraphs when true enables CoreML EP to run on subgraphs in the body
-// of control flow operators.
-// Default is false.
-func (o *CoreMLProviderOptions) SetEnableOnSubgraphs(enable bool) {
-	if enable {
-		o.options["EnableOnSubgraphs"] = "1"
-	} else {
-		o.options["EnableOnSubgraphs"] = "0"
-	}
-}
-
-// SetSpecializationStrategy allows tailoring the specialization strategy.
-// Available since macOS>=10.15 or iOS>=18.0.
-// Default is CoreMLSpecializationStrategyDefault.
-func (o *CoreMLProviderOptions) SetSpecializationStrategy(strategy CoreMLSpecializationStrategy) {
-	o.options["SpecializationStrategy"] = string(strategy)
-}
-
-// SetProfileComputePlan when true logs hardware dispatch and estimated execution time.
-// Default is false.
-func (o *CoreMLProviderOptions) SetProfileComputePlan(enable bool) {
-	if enable {
-		o.options["ProfileComputePlan"] = "1"
-	} else {
-		o.options["ProfileComputePlan"] = "0"
-	}
-}
-
-// SetAllowLowPrecisionAccumulationOnGPU when true uses float16 for accumulation.
-// Default is false (uses float32).
-func (o *CoreMLProviderOptions) SetAllowLowPrecisionAccumulationOnGPU(allow bool) {
-	if allow {
-		o.options["AllowLowPrecisionAccumulationOnGPU"] = "1"
-	} else {
-		o.options["AllowLowPrecisionAccumulationOnGPU"] = "0"
-	}
-}
-
-// SetModelCacheDirectory specifies path to store compiled CoreML models.
-// Default is empty (cache disabled).
-func (o *CoreMLProviderOptions) SetModelCacheDirectory(path string) {
-	o.options["ModelCacheDirectory"] = path
-}
-
-// Update allows updating multiple options at once with a map.
-// This is similar to the Update method in other provider options.
-func (o *CoreMLProviderOptions) Update(options map[string]string) {
-	for k, v := range options {
-		o.options[k] = v
-	}
-}
 
 // Enables the CoreML backend for the given session options on supported
-// platforms.
+// platforms. 
 // The meanings of the flag bits are currently defined in the
 // coreml_provider_factory.h file which is provided in the include/ directory of
 // the onnxruntime releases for Apple platforms.
@@ -1577,17 +1436,9 @@ func (o *SessionOptions) AppendExecutionProviderCoreML(flags uint32) error {
 //
 // For CoreML options, see:
 // https://onnxruntime.ai/docs/execution-providers/CoreML-ExecutionProvider.html
-func (o *SessionOptions) AppendExecutionProviderCoreMLV2(coreMLOptions *CoreMLProviderOptions) error {
-	// Handle case with no options
-	if coreMLOptions == nil {
-		status := C.AppendExecutionProviderCoreMLV2(o.o, nil, nil, 0)
-		if status != nil {
-			return statusToError(status)
-		}
-		return nil
-	}
+func (o *SessionOptions) AppendExecutionProviderCoreMLV2(options map[string]string) error {
 
-	options := coreMLOptions.options
+	// Handle case with no options
 	if len(options) == 0 {
 		status := C.AppendExecutionProviderCoreMLV2(o.o, nil, nil, 0)
 		if status != nil {

--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -1415,20 +1415,212 @@ func (o *SessionOptions) AppendExecutionProviderTensorRT(
 	return nil
 }
 
+// CoreMLModelFormat represents the format of the CoreML model.
+type CoreMLModelFormat string
+
+const (
+	// CoreMLModelFormatMLProgram creates an MLProgram format model.
+	// Requires CoreML 5 or later (iOS 15+ or macOS 12+).
+	CoreMLModelFormatMLProgram CoreMLModelFormat = "MLProgram"
+
+	// CoreMLModelFormatNeuralNetwork creates a NeuralNetwork format model.
+	// Requires CoreML 3 or later (iOS 13+ or macOS 10.15+).
+	CoreMLModelFormatNeuralNetwork CoreMLModelFormat = "NeuralNetwork"
+)
+
+// CoreMLComputeUnits represents the compute units to use with CoreML.
+type CoreMLComputeUnits string
+
+const (
+	// CoreMLComputeUnitsCPUOnly limits CoreML to running on CPU only.
+	CoreMLComputeUnitsCPUOnly CoreMLComputeUnits = "CPUOnly"
+
+	// CoreMLComputeUnitsCPUAndNeuralEngine enables CoreML EP for Apple devices
+	// with a compatible Apple Neural Engine (ANE).
+	CoreMLComputeUnitsCPUAndNeuralEngine CoreMLComputeUnits = "CPUAndNeuralEngine"
+
+	// CoreMLComputeUnitsCPUAndGPU enables CoreML EP for Apple devices
+	// with a compatible GPU.
+	CoreMLComputeUnitsCPUAndGPU CoreMLComputeUnits = "CPUAndGPU"
+
+	// CoreMLComputeUnitsALL enables CoreML EP for all compatible Apple devices.
+	CoreMLComputeUnitsALL CoreMLComputeUnits = "ALL"
+)
+
+// CoreMLSpecializationStrategy represents the specialization strategy for CoreML models.
+type CoreMLSpecializationStrategy string
+
+const (
+	// CoreMLSpecializationStrategyDefault uses the default specialization strategy.
+	CoreMLSpecializationStrategyDefault CoreMLSpecializationStrategy = "Default"
+
+	// CoreMLSpecializationStrategyFastPrediction optimizes for prediction speed.
+	CoreMLSpecializationStrategyFastPrediction CoreMLSpecializationStrategy = "FastPrediction"
+)
+
+// CoreMLProviderOptions defines the options for the CoreML execution provider.
+type CoreMLProviderOptions struct {
+	// Internal map to store the options
+	options map[string]string
+}
+
+// NewCoreMLProviderOptions creates a new CoreMLProviderOptions with default values.
+func NewCoreMLProviderOptions() *CoreMLProviderOptions {
+	options := &CoreMLProviderOptions{
+		options: make(map[string]string),
+	}
+
+	// Set default values
+	options.options["ModelFormat"] = string(CoreMLModelFormatNeuralNetwork)
+	options.options["MLComputeUnits"] = string(CoreMLComputeUnitsALL)
+	options.options["RequireStaticInputShapes"] = "0"
+	options.options["EnableOnSubgraphs"] = "0"
+	options.options["SpecializationStrategy"] = string(CoreMLSpecializationStrategyDefault)
+	options.options["ProfileComputePlan"] = "0"
+	options.options["AllowLowPrecisionAccumulationOnGPU"] = "0"
+
+	return options
+}
+
+// SetModelFormat sets the CoreML model format to use.
+// Default is CoreMLModelFormatNeuralNetwork.
+func (o *CoreMLProviderOptions) SetModelFormat(format CoreMLModelFormat) {
+	o.options["ModelFormat"] = string(format)
+}
+
+// SetMLComputeUnits specifies which compute units to enable.
+// Default is CoreMLComputeUnitsALL.
+func (o *CoreMLProviderOptions) SetMLComputeUnits(units CoreMLComputeUnits) {
+	o.options["MLComputeUnits"] = string(units)
+}
+
+// SetRequireStaticInputShapes when true only allows the CoreML EP to take nodes
+// with inputs that have static shapes.
+// Default is false.
+func (o *CoreMLProviderOptions) SetRequireStaticInputShapes(require bool) {
+	if require {
+		o.options["RequireStaticInputShapes"] = "1"
+	} else {
+		o.options["RequireStaticInputShapes"] = "0"
+	}
+}
+
+// SetEnableOnSubgraphs when true enables CoreML EP to run on subgraphs in the body
+// of control flow operators.
+// Default is false.
+func (o *CoreMLProviderOptions) SetEnableOnSubgraphs(enable bool) {
+	if enable {
+		o.options["EnableOnSubgraphs"] = "1"
+	} else {
+		o.options["EnableOnSubgraphs"] = "0"
+	}
+}
+
+// SetSpecializationStrategy allows tailoring the specialization strategy.
+// Available since macOS>=10.15 or iOS>=18.0.
+// Default is CoreMLSpecializationStrategyDefault.
+func (o *CoreMLProviderOptions) SetSpecializationStrategy(strategy CoreMLSpecializationStrategy) {
+	o.options["SpecializationStrategy"] = string(strategy)
+}
+
+// SetProfileComputePlan when true logs hardware dispatch and estimated execution time.
+// Default is false.
+func (o *CoreMLProviderOptions) SetProfileComputePlan(enable bool) {
+	if enable {
+		o.options["ProfileComputePlan"] = "1"
+	} else {
+		o.options["ProfileComputePlan"] = "0"
+	}
+}
+
+// SetAllowLowPrecisionAccumulationOnGPU when true uses float16 for accumulation.
+// Default is false (uses float32).
+func (o *CoreMLProviderOptions) SetAllowLowPrecisionAccumulationOnGPU(allow bool) {
+	if allow {
+		o.options["AllowLowPrecisionAccumulationOnGPU"] = "1"
+	} else {
+		o.options["AllowLowPrecisionAccumulationOnGPU"] = "0"
+	}
+}
+
+// SetModelCacheDirectory specifies path to store compiled CoreML models.
+// Default is empty (cache disabled).
+func (o *CoreMLProviderOptions) SetModelCacheDirectory(path string) {
+	o.options["ModelCacheDirectory"] = path
+}
+
+// Update allows updating multiple options at once with a map.
+// This is similar to the Update method in other provider options.
+func (o *CoreMLProviderOptions) Update(options map[string]string) {
+	for k, v := range options {
+		o.options[k] = v
+	}
+}
+
 // Enables the CoreML backend for the given session options on supported
-// platforms. Unlike the other AppendExecutionProvider* functions, this one
-// only takes a bitfield of flags rather than an options object, though it
-// wouldn't suprise me if onnxruntime deprecated this API in the future as it
-// did with the others. If that happens, we'll likely add a
-// CoreMLProviderOptions struct and an AppendExecutionProviderCoreMLV2 function
-// to the Go wrapper library, but for now the simpler API is the only thing
-// available.
-//
-// Regardless, the meanings of the flag bits are currently defined in the
+// platforms.
+// The meanings of the flag bits are currently defined in the
 // coreml_provider_factory.h file which is provided in the include/ directory of
 // the onnxruntime releases for Apple platforms.
+// AppendExecutionProviderCoreML is now deprecated. Please use AppendExecutionProviderCoreMLV2 instead.
+// See: https://onnxruntime.ai/docs/execution-providers/CoreML-ExecutionProvider.html
 func (o *SessionOptions) AppendExecutionProviderCoreML(flags uint32) error {
 	status := C.AppendExecutionProviderCoreML(o.o, C.uint32_t(flags))
+	if status != nil {
+		return statusToError(status)
+	}
+	return nil
+}
+
+// AppendExecutionProviderCoreMLV2 is the new API for adding CoreML provider to ONNX Runtime.
+// This is the recommended way to add CoreML provider as of ONNX Runtime 1.20.0.
+//
+// For CoreML options, see:
+// https://onnxruntime.ai/docs/execution-providers/CoreML-ExecutionProvider.html
+func (o *SessionOptions) AppendExecutionProviderCoreMLV2(coreMLOptions *CoreMLProviderOptions) error {
+	// Handle case with no options
+	if coreMLOptions == nil {
+		status := C.AppendExecutionProviderCoreMLV2(o.o, nil, nil, 0)
+		if status != nil {
+			return statusToError(status)
+		}
+		return nil
+	}
+
+	options := coreMLOptions.options
+	if len(options) == 0 {
+		status := C.AppendExecutionProviderCoreMLV2(o.o, nil, nil, 0)
+		if status != nil {
+			return statusToError(status)
+		}
+		return nil
+	}
+
+	// Convert map to arrays of keys and values
+	keys := make([]*C.char, len(options))
+	values := make([]*C.char, len(options))
+
+	i := 0
+	for k, v := range options {
+		keys[i] = C.CString(k)
+		values[i] = C.CString(v)
+		i++
+	}
+
+	// Clean up C strings when done
+	defer func() {
+		for _, s := range keys {
+			C.free(unsafe.Pointer(s))
+		}
+		for _, s := range values {
+			C.free(unsafe.Pointer(s))
+		}
+	}()
+
+	// Call C function
+	status := C.AppendExecutionProviderCoreMLV2(o.o,
+		&keys[0], &values[0], C.size_t(len(options)))
+
 	if status != nil {
 		return statusToError(status)
 	}

--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -1415,9 +1415,8 @@ func (o *SessionOptions) AppendExecutionProviderTensorRT(
 	return nil
 }
 
-
 // Enables the CoreML backend for the given session options on supported
-// platforms. 
+// platforms.
 // The meanings of the flag bits are currently defined in the
 // coreml_provider_factory.h file which is provided in the include/ directory of
 // the onnxruntime releases for Apple platforms.
@@ -1448,25 +1447,9 @@ func (o *SessionOptions) AppendExecutionProviderCoreMLV2(options map[string]stri
 	}
 
 	// Convert map to arrays of keys and values
-	keys := make([]*C.char, len(options))
-	values := make([]*C.char, len(options))
-
-	i := 0
-	for k, v := range options {
-		keys[i] = C.CString(k)
-		values[i] = C.CString(v)
-		i++
-	}
-
-	// Clean up C strings when done
-	defer func() {
-		for _, s := range keys {
-			C.free(unsafe.Pointer(s))
-		}
-		for _, s := range values {
-			C.free(unsafe.Pointer(s))
-		}
-	}()
+	keys, values := mapToCStrings(options)
+	defer freeCStrings(keys)
+	defer freeCStrings(values)
 
 	// Call C function
 	status := C.AppendExecutionProviderCoreMLV2(o.o,

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -2069,10 +2069,23 @@ func getCoreMLV2SessionOptions(t testing.TB) *SessionOptions {
 		t.Fatalf("Error creating session options: %s\n", e)
 	}
 
-	// Create CoreML provider options
-	coreMLOptions := NewCoreMLProviderOptions()
+	// Use the new API with CoreML provider options
+	coreMLOptions := map[string]string{
+		"ModelFormat":                        "NeuralNetwork", // Use NeuralNetwork format instead of MLProgram
+		"MLComputeUnits":                     "ALL",           // Use all available compute units
+		"RequireStaticInputShapes":           "0",             // Allow dynamic shapes
+		"EnableOnSubgraphs":                  "0",             // Don't enable on subgraphs
+		"ModelCacheDirectory":                "/tmp",          // Set the cache directory to /tmp
+		"AllowLowPrecisionAccumulationOnGPU": "1",             // Enable low precision acceleration
+	}
 
-	// Apply the CoreML options to the session
+	// If options can't be empty, catch any potential problems
+	if len(coreMLOptions) == 0 {
+		options.Destroy()
+		t.Skipf("Empty CoreML options map. This should not happen.\n")
+		return nil
+	}
+
 	e = options.AppendExecutionProviderCoreMLV2(coreMLOptions)
 	if e != nil {
 		options.Destroy()

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -2063,6 +2063,42 @@ func BenchmarkCoreMLSession(b *testing.B) {
 	benchmarkBigSessionWithOptions(b, sessionOptions)
 }
 
+func getCoreMLV2SessionOptions(t testing.TB) *SessionOptions {
+	options, e := NewSessionOptions()
+	if e != nil {
+		t.Fatalf("Error creating session options: %s\n", e)
+	}
+
+	// Create CoreML provider options
+	coreMLOptions := NewCoreMLProviderOptions()
+
+	// Apply the CoreML options to the session
+	e = options.AppendExecutionProviderCoreMLV2(coreMLOptions)
+	if e != nil {
+		options.Destroy()
+		t.Skipf("Couldn't enable CoreML: %s. This may be due to your system "+
+			"or onnxruntime library version not supporting CoreML.\n", e)
+	}
+	return options
+}
+
+func TestCoreMLV2Session(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+	sessionOptions := getCoreMLV2SessionOptions(t)
+	defer sessionOptions.Destroy()
+	testBigSessionWithOptions(t, sessionOptions)
+}
+
+func BenchmarkCoreMLV2Session(b *testing.B) {
+	b.StopTimer()
+	InitializeRuntime(b)
+	defer CleanupRuntime(b)
+	sessionOptions := getCoreMLV2SessionOptions(b)
+	defer sessionOptions.Destroy()
+	benchmarkBigSessionWithOptions(b, sessionOptions)
+}
+
 func getDirectMLSessionOptions(t testing.TB) *SessionOptions {
 	options, e := NewSessionOptions()
 	if e != nil {

--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -184,6 +184,15 @@ OrtStatus *AppendExecutionProviderCoreML(OrtSessionOptions *o,
   return append_coreml_provider_fn(o, flags);
 }
 
+OrtStatus *AppendExecutionProviderCoreMLV2(OrtSessionOptions *o,
+  const char **keys, const char **values, size_t num_options) {
+  if (!append_coreml_provider_fn) {
+    return ort_api->CreateStatus(ORT_NOT_IMPLEMENTED, "Your platform or "
+      "onnxruntime library does not support CoreML");
+  }
+  return ort_api->SessionOptionsAppendExecutionProvider(o, "CoreML", keys, values, num_options);
+}
+
 OrtStatus *AppendExecutionProviderDirectML(OrtSessionOptions *o,
   int device_id) {
   DummyOrtDMLAPI *dml_api = NULL;
@@ -475,4 +484,3 @@ OrtStatus *CreateOrtValue(OrtValue **in, size_t num_values,
   return ort_api->CreateValue((const OrtValue* const*) in, num_values,
     value_type, out);
 }
-

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -136,6 +136,11 @@ OrtStatus *AppendExecutionProviderTensorRTV2(OrtSessionOptions *o,
 OrtStatus *AppendExecutionProviderCoreML(OrtSessionOptions *o,
   uint32_t flags);
 
+// Wraps OrtApi method SessionOptionsAppendExecutionProvider specifically for CoreML
+// with the new options-based API while including the check that coreml is supported.
+OrtStatus *AppendExecutionProviderCoreMLV2(OrtSessionOptions *o,
+  const char **keys, const char **values, size_t num_options);
+
 // Wraps getting the OrtDmlApi struct and calling
 // dml_api->SessionOptionsAppendExecutionProvider_DML.
 OrtStatus *AppendExecutionProviderDirectML(OrtSessionOptions *o,


### PR DESCRIPTION
As foreshadowed, ONNX Runtime has refactored CoreML support such that we can now have a CoreMLProviderOptions struct and an AppendExecutionProviderCoreMLV2 function. 

> Deprecated APIs OrtSessionOptionsAppendExecutionProvider_CoreML in ONNX Runtime 1.20.0. Please use OrtSessionOptionsAppendExecutionProvider instead.
https://onnxruntime.ai/docs/execution-providers/CoreML-ExecutionProvider.html#usage

This exposes more options than the bitmask did. I've tested a variety of the options using this branch on a Macbook M1 Max. 