### PR TITLE
Add plugin execution provider (V2) API bindings

### DIFF
--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -305,6 +305,117 @@ func UnregisterExecutionProviderLibrary(registrationName string) error {
 	return nil
 }
 
+// EpDevice is an opaque handle to an OrtEpDevice: a single (execution
+// provider, hardware device) pair surfaced by an execution-provider plugin.
+//
+// EpDevice values returned from GetEpDevices are owned by the OrtEnv. Callers
+// must NOT call any release function on them; the underlying OrtEpDevice
+// remains valid until the originating plugin library is unregistered (via
+// UnregisterExecutionProviderLibrary) or the runtime environment is destroyed.
+type EpDevice struct {
+	p *C.OrtEpDevice
+}
+
+// EpName returns the execution provider name that owns this device, e.g.
+// "QNNExecutionProvider" or "OpenVINOExecutionProvider".
+func (d EpDevice) EpName() string {
+	if d.p == nil {
+		return ""
+	}
+	return C.GoString(C.EpDeviceEpName(d.p))
+}
+
+// EpVendor returns the execution provider's vendor string, e.g. "Microsoft"
+// or "Qualcomm".
+func (d EpDevice) EpVendor() string {
+	if d.p == nil {
+		return ""
+	}
+	return C.GoString(C.EpDeviceEpVendor(d.p))
+}
+
+// GetEpDevices returns the list of OrtEpDevice instances known to the
+// runtime, including those contributed by plugin execution providers loaded
+// via RegisterExecutionProviderLibrary. The returned EpDevices remain valid
+// until the corresponding plugin library is unregistered or the environment
+// is destroyed.
+func GetEpDevices() ([]EpDevice, error) {
+	if !IsInitialized() {
+		return nil, NotInitializedError
+	}
+	var raw **C.OrtEpDevice
+	var count C.size_t
+	status := C.GetEpDevices(ortEnv,
+		(***C.OrtEpDevice)(unsafe.Pointer(&raw)), &count)
+	if status != nil {
+		return nil, statusToError(status)
+	}
+	n := int(count)
+	if n == 0 || raw == nil {
+		return nil, nil
+	}
+	// raw points to an array of n const OrtEpDevice* owned by the env.
+	devices := make([]EpDevice, n)
+	src := unsafe.Slice(raw, n)
+	for i := 0; i < n; i++ {
+		devices[i] = EpDevice{p: src[i]}
+	}
+	return devices, nil
+}
+
+// AppendExecutionProviderV2 attaches a plugin execution provider to these
+// session options using one or more OrtEpDevice instances obtained from
+// GetEpDevices. All provided devices must belong to the same execution
+// provider (they are different hardware targets within that EP).
+//
+// This is the plugin-aware path; use it for any execution provider loaded
+// through RegisterExecutionProviderLibrary (QNN, newer OpenVINO, etc.). For
+// execution providers compiled into libonnxruntime, use the dedicated
+// wrappers (AppendExecutionProviderCUDA, AppendExecutionProviderCoreMLV2,
+// ...) or the V1 string-based AppendExecutionProvider.
+//
+// Wraps the C API SessionOptionsAppendExecutionProvider_V2.
+func (o *SessionOptions) AppendExecutionProviderV2(devices []EpDevice,
+	options map[string]string) error {
+	if len(devices) == 0 {
+		return fmt.Errorf("AppendExecutionProviderV2 requires at least one EpDevice")
+	}
+	for i, d := range devices {
+		if d.p == nil {
+			return fmt.Errorf("AppendExecutionProviderV2: devices[%d] "+
+				"is the zero EpDevice", i)
+		}
+	}
+
+	// Marshal device pointers into a contiguous C array. We allocate via
+	// C.malloc to keep the storage stable for the duration of the call (Go
+	// slices may move under GC).
+	ptrSize := C.size_t(unsafe.Sizeof(uintptr(0)))
+	arr := C.malloc(ptrSize * C.size_t(len(devices)))
+	defer C.free(arr)
+	dst := unsafe.Slice((**C.OrtEpDevice)(arr), len(devices))
+	for i, d := range devices {
+		dst[i] = d.p
+	}
+
+	var keysPtr, valuesPtr **C.char
+	if len(options) != 0 {
+		keys, values := mapToCStrings(options)
+		defer freeCStrings(keys)
+		defer freeCStrings(values)
+		keysPtr = &(keys[0])
+		valuesPtr = &(values[0])
+	}
+
+	status := C.AppendExecutionProviderV2(o.o, ortEnv,
+		(**C.OrtEpDevice)(arr), C.size_t(len(devices)),
+		keysPtr, valuesPtr, C.size_t(len(options)))
+	if status != nil {
+		return statusToError(status)
+	}
+	return nil
+}
+
 // ArenaCfg wraps OrtArenaCfg for arena-based allocator configuration.
 type ArenaCfg struct {
 	c *C.OrtArenaCfg

--- a/onnxruntime_go.go
+++ b/onnxruntime_go.go
@@ -387,15 +387,14 @@ func (o *SessionOptions) AppendExecutionProviderV2(devices []EpDevice,
 		}
 	}
 
-	// Marshal device pointers into a contiguous C array. We allocate via
-	// C.malloc to keep the storage stable for the duration of the call (Go
-	// slices may move under GC).
-	ptrSize := C.size_t(unsafe.Sizeof(uintptr(0)))
-	arr := C.malloc(ptrSize * C.size_t(len(devices)))
-	defer C.free(arr)
-	dst := unsafe.Slice((**C.OrtEpDevice)(arr), len(devices))
+	arr := make([]*C.OrtEpDevice, len(devices))
 	for i, d := range devices {
-		dst[i] = d.p
+		arr[i] = d.p
+	}
+	var arrPtr **C.OrtEpDevice
+	if len(arr) != 0 {
+		// Avoid dereferencing arr[0] if the array is empty, same as with the options map.
+		arrPtr = &(arr[0])
 	}
 
 	var keysPtr, valuesPtr **C.char
@@ -407,8 +406,7 @@ func (o *SessionOptions) AppendExecutionProviderV2(devices []EpDevice,
 		valuesPtr = &(values[0])
 	}
 
-	status := C.AppendExecutionProviderV2(o.o, ortEnv,
-		(**C.OrtEpDevice)(arr), C.size_t(len(devices)),
+	status := C.AppendExecutionProviderV2(o.o, ortEnv, arrPtr, C.size_t(len(arr)),
 		keysPtr, valuesPtr, C.size_t(len(options)))
 	if status != nil {
 		return statusToError(status)

--- a/onnxruntime_test.go
+++ b/onnxruntime_test.go
@@ -2566,3 +2566,111 @@ func TestSharedAllocator(t *testing.T) {
 		s.Destroy()
 	}
 }
+
+// Sanity check for the plugin EP (V2) API: GetEpDevices must return without
+// error and produce well-formed (non-empty EpName, non-nil) entries when any
+// are present. We do not assert a specific count because the device list
+// depends on which execution providers were compiled into the loaded
+// onnxruntime shared library and which (if any) plugin libraries were
+// registered before the test.
+func TestGetEpDevices(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+
+	devices, e := GetEpDevices()
+	if e != nil {
+		t.Fatalf("GetEpDevices returned an error: %s\n", e)
+	}
+	t.Logf("GetEpDevices returned %d device(s)\n", len(devices))
+	for i, d := range devices {
+		name := d.EpName()
+		vendor := d.EpVendor()
+		t.Logf("  device %d: ep=%q vendor=%q\n", i, name, vendor)
+		if name == "" {
+			t.Errorf("device %d: empty EpName\n", i)
+		}
+	}
+}
+
+// AppendExecutionProviderV2 must reject an empty device slice rather than
+// dereferencing a nil pointer in the C call.
+func TestAppendExecutionProviderV2EmptyDevices(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+
+	opts, e := NewSessionOptions()
+	if e != nil {
+		t.Fatalf("NewSessionOptions: %s\n", e)
+	}
+	defer opts.Destroy()
+
+	if e := opts.AppendExecutionProviderV2(nil, nil); e == nil {
+		t.Fatalf("expected error from AppendExecutionProviderV2 with nil " +
+			"devices, got nil\n")
+	}
+	if e := opts.AppendExecutionProviderV2([]EpDevice{}, nil); e == nil {
+		t.Fatalf("expected error from AppendExecutionProviderV2 with empty " +
+			"devices slice, got nil\n")
+	}
+}
+
+// AppendExecutionProviderV2 must reject a slice that contains the zero
+// EpDevice (nil C pointer) before reaching the C call. This guards against
+// callers manually constructing EpDevice{} values.
+func TestAppendExecutionProviderV2NilDevicePointer(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+
+	opts, e := NewSessionOptions()
+	if e != nil {
+		t.Fatalf("NewSessionOptions: %s\n", e)
+	}
+	defer opts.Destroy()
+
+	if e := opts.AppendExecutionProviderV2([]EpDevice{{}}, nil); e == nil {
+		t.Fatalf("expected error from AppendExecutionProviderV2 with zero " +
+			"EpDevice, got nil\n")
+	}
+}
+
+// When an EpDevice is available, AppendExecutionProviderV2 must surface ORT
+// errors as Go errors rather than panicking. Passing an obviously-bogus
+// option key is the simplest way to provoke a Status without needing a
+// specific plugin to be loaded. The test is skipped when no EpDevice is
+// available (e.g., a minimal onnxruntime build).
+func TestAppendExecutionProviderV2InvalidOption(t *testing.T) {
+	InitializeRuntime(t)
+	defer CleanupRuntime(t)
+
+	devices, e := GetEpDevices()
+	if e != nil {
+		t.Fatalf("GetEpDevices: %s\n", e)
+	}
+	if len(devices) == 0 {
+		t.Skipf("no EpDevices available on this build; skipping")
+	}
+
+	opts, e := NewSessionOptions()
+	if e != nil {
+		t.Fatalf("NewSessionOptions: %s\n", e)
+	}
+	defer opts.Destroy()
+
+	// Use a single device so all entries belong to the same EP, as required
+	// by SessionOptionsAppendExecutionProvider_V2.
+	e = opts.AppendExecutionProviderV2(devices[:1], map[string]string{
+		"definitely_not_a_real_option_key": "x",
+	})
+	// Either ORT rejects the unknown option (preferred) or it silently
+	// accepts it. Both are valid library behaviours; what we care about is
+	// that no panic / segfault occurs and that any reported error is a
+	// proper Go error string.
+	if e != nil {
+		t.Logf("ORT rejected bogus option as expected: %s\n", e)
+		if e.Error() == "" {
+			t.Errorf("error returned with empty message\n")
+		}
+		return
+	}
+	t.Logf("ORT silently accepted unknown option (also acceptable)\n")
+}

--- a/onnxruntime_wrapper.c
+++ b/onnxruntime_wrapper.c
@@ -248,6 +248,26 @@ OrtStatus *UnregisterExecutionProviderLibrary(OrtEnv *env,
   return ort_api->UnregisterExecutionProviderLibrary(env, registration_name);
 }
 
+OrtStatus *GetEpDevices(OrtEnv *env,
+  const OrtEpDevice * const **out_devices, size_t *out_count) {
+  return ort_api->GetEpDevices(env, out_devices, out_count);
+}
+
+const char *EpDeviceEpName(const OrtEpDevice *device) {
+  return ort_api->EpDevice_EpName(device);
+}
+
+const char *EpDeviceEpVendor(const OrtEpDevice *device) {
+  return ort_api->EpDevice_EpVendor(device);
+}
+
+OrtStatus *AppendExecutionProviderV2(OrtSessionOptions *o, OrtEnv *env,
+  const OrtEpDevice * const *ep_devices, size_t num_ep_devices,
+  const char **keys, const char **values, size_t num_keys) {
+  return ort_api->SessionOptionsAppendExecutionProvider_V2(o, env, ep_devices,
+    num_ep_devices, keys, values, num_keys);
+}
+
 OrtStatus *CreateArenaCfg(size_t max_mem, int arena_extend_strategy,
   int initial_chunk_size_bytes, int max_dead_bytes_per_chunk,
   OrtArenaCfg **out) {

--- a/onnxruntime_wrapper.h
+++ b/onnxruntime_wrapper.h
@@ -178,6 +178,23 @@ OrtStatus *RegisterExecutionProviderLibrary(OrtEnv *env,
 OrtStatus *UnregisterExecutionProviderLibrary(OrtEnv *env,
   const char *registration_name);
 
+// Wraps ort_api->GetEpDevices. The returned array is owned by the OrtEnv and
+// must NOT be freed by the caller; the pointers inside it remain valid until
+// the corresponding plugin library is unregistered or the env is released.
+OrtStatus *GetEpDevices(OrtEnv *env,
+  const OrtEpDevice * const **out_devices, size_t *out_count);
+
+// Wraps ort_api->EpDevice_EpName.
+const char *EpDeviceEpName(const OrtEpDevice *device);
+
+// Wraps ort_api->EpDevice_EpVendor.
+const char *EpDeviceEpVendor(const OrtEpDevice *device);
+
+// Wraps ort_api->SessionOptionsAppendExecutionProvider_V2.
+OrtStatus *AppendExecutionProviderV2(OrtSessionOptions *o, OrtEnv *env,
+  const OrtEpDevice * const *ep_devices, size_t num_ep_devices,
+  const char **keys, const char **values, size_t num_keys);
+
 // Wraps ort_api->CreateArenaCfg
 OrtStatus *CreateArenaCfg(size_t max_mem, int arena_extend_strategy,
   int initial_chunk_size_bytes, int max_dead_bytes_per_chunk,


### PR DESCRIPTION
                                                                                                                                                                                                                                                                         
  ## Motivation                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                             
  The pre-existing V1 string-based `AppendExecutionProvider("Foo", opts)` only recognises execution providers that are compiled into `libonnxruntime` itself. For execution providers that ship as separate shared libraries and are loaded at runtime via                   
  `RegisterExecutionProviderLibrary` - `QNNExecutionProvider`, the newer `OpenVINOExecutionProvider`, third-party vendor plugins - the V1 call returns `"<name> execution provider is not supported in this build"`.                                                         
                                                                                                                                                                                                                                                                             
  ORT 1.21 introduced a plugin-aware "V2" path:                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                             
  1. `RegisterExecutionProviderLibrary(name, path)` - already wrapped in this library.                                                                                                                                                                                       
  2. `GetEpDevices(env, ...)` - enumerate `OrtEpDevice` instances now known to the env.                                                                                                                                                                                      
  3. `SessionOptionsAppendExecutionProvider_V2(opts, env, devices, ..., keys, values, ...)` - attach one or more devices belonging to a single EP to a session.                                                                                                              
                                                                                                                                                                                                                                                                             
  Steps 2 and 3 weren't wrapped, so loading a plugin EP via `RegisterExecutionProviderLibrary` from this library left it unusable. This PR adds the missing rung.                                                                                                            
                                                                                                                                                                                                                                                                             
  ## Changes                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                             
  - `onnxruntime_wrapper.{h,c}`: thin C wrappers around `ort_api->GetEpDevices`, `EpDevice_EpName`, `EpDevice_EpVendor`, and `SessionOptionsAppendExecutionProvider_V2`. Cgo can't call function pointers directly, so the existing pattern is mirrored.                     
  - `onnxruntime_go.go` (per CONTRIBUTING.md, no new Go file):                                                                                                                                                                                                               
    - `EpDevice` - opaque handle. Owned by the env; never released by the caller.      
    - `(EpDevice).EpName()`, `EpVendor()` - accessors.                                                                                                                                                                                                                       
    - `GetEpDevices()` - enumerates the device list.                 
    - `(*SessionOptions).AppendExecutionProviderV2(devices, options)` - attaches devices, marshals string options identically to the existing V1 wrapper.                                                                                                                    
  - `onnxruntime_test.go`:                                                                                                                                                                                                                                                   
    - `TestGetEpDevices` enumerates and validates non-empty `EpName` for each entry.
    - `TestAppendExecutionProviderV2EmptyDevices` asserts the Go wrapper rejects empty/nil device slices in Go before reaching C.                                                                                                                                            
    - `TestAppendExecutionProviderV2NilDevicePointer` asserts the Go wrapper rejects a slice containing the zero `EpDevice` value.
    - `TestAppendExecutionProviderV2InvalidOption` exercises the option-marshalling path with a bogus key and ensures any returned error is a proper Go error.                                                                                                               
                                                                                                                                                                                                                                                                             
  ## Test results                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                             
  === RUN   TestGetEpDevices                                                                                                                                                                                                                                                 
      GetEpDevices returned 2 device(s)                                                
        device 0: ep="CPUExecutionProvider" vendor="Microsoft"                                                                                                                                                                                                               
        device 1: ep="WebGpuExecutionProvider" vendor="Microsoft"
  --- PASS: TestGetEpDevices                                                                                                                                                                                                                                                 
  === RUN   TestAppendExecutionProviderV2EmptyDevices                                                                                                                                                                                                                        
  --- PASS: TestAppendExecutionProviderV2EmptyDevices                                                                                                                                                                                                                        
  === RUN   TestAppendExecutionProviderV2NilDevicePointer                                                                                                                                                                                                                    
  --- PASS: TestAppendExecutionProviderV2NilDevicePointer                                                                                                                                                                                                                    
  === RUN   TestAppendExecutionProviderV2InvalidOption                                                                                                                                                                                                                       
      ORT silently accepted unknown option (also acceptable)                                                                                                                                                                                                                 
  --- PASS: TestAppendExecutionProviderV2InvalidOption                                                                                                                                                                                                                       
  PASS                                                                                                                                                                                                                                                                       
  ok    github.com/yalue/onnxruntime_go 27.270s                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                             
  Run on the bundled `test_data/onnxruntime_arm64.dylib` (macOS arm64). Full `go test -v -bench=.` is clean; no regressions in pre-existing tests. I don't have access to a system with a plugin EP currently registered to assert against `AppendExecutionProviderV2`       
  end-to-end inside the test binary, but the call has been exercised in production against `QNNExecutionProvider` (Qualcomm Hexagon NPU on QCS6490) and works as expected.